### PR TITLE
Removed dependency on MINT python client for IO exploration

### DIFF
--- a/REST-Server/openapi_server/controllers/exploration_controller.py
+++ b/REST-Server/openapi_server/controllers/exploration_controller.py
@@ -158,7 +158,9 @@ def model_io_post():  # noqa: E501
             inputs_outputs = []
             if type_ == 'input':
                 for config_id in configuration_ids:
-                    api_response = api_instance.get_inputs_by_modelconfiguration(config_id, username=username)
+                    response = requests.get(f"https://api.models.mint.isi.edu/v0.0.2/modelconfiguration/{config_id}/inputs?username=modelservice")
+                    api_response = response.json()
+                    
                     for io in api_response:
                         io_ = util._parse_io(io, url, request_headers)
                         if io_:

--- a/REST-Server/openapi_server/util.py
+++ b/REST-Server/openapi_server/util.py
@@ -225,14 +225,14 @@ def _get_variables(file):
 
 def _parse_io(io, url, request_headers):
     """Parse MINT input/output object into a dictionary"""
-    io_ = io.to_dict()
+    io_ = io
     
     # only if ID is a valid UUID4 otherwise skip dataset
     if is_valid_uuid(io_['id']):
         io_['name'] = io_.pop('label')
-        io_['filetype'] = format_stringed_array(io_.pop('has_format'))
+        io_['filetype'] = format_stringed_array(io_.pop('hasFormat'))
         io_.pop('type')
-        io_.pop('has_dimensionality')
+        io_.pop('hasDimensionality')
 
         # query DCAT for variable information related to dataset
         q = {
@@ -254,7 +254,7 @@ def _parse_io(io, url, request_headers):
         for var in std_vars:
             std_vars_dict[var['standard_variable_id']] = var
         
-        io_.pop('has_presentation')
+        io_.pop('hasPresentation')
         io_['variables'] = []
         for v in variables:
             v['name'] = v.pop('variable_name')


### PR DESCRIPTION
This dependency was removed was removed due to a bug that was identified by @jgawrilo on 6/28/2019 (see this issue [https://github.com/mintproject/MINT-ModelCatalogAPI-client/issues/10](https://github.com/mintproject/MINT-ModelCatalogAPI-client/issues/10)). This PR resolves this by making direct calls to the MINT API.