### PR TITLE
Add `/available_results` endpoint

### DIFF
--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -28,7 +28,7 @@ r = redis.Redis(host=config['REDIS']['HOST'],
 client = docker.from_env()
 containers = client.containers
 
-available_models = ['population_model', 'malnutrition_model', 'fsc']
+available_models = ['population_model', 'malnutrition_model', 'FSC']
 
 def list_runs_model_name_get(ModelName):  # noqa: E501
     """Obtain a list of runs for a given model
@@ -153,6 +153,28 @@ def run_status_run_idget(RunID):  # noqa: E501
     :rtype: RunStatus
     """
     return update_run_status(RunID)
+
+
+def available_results_get():  # noqa: E501
+    """Obtain a list of run results
+
+    Return a list of all available run results. # noqa: E501
+
+
+    :rtype: List[RunResults]
+    """
+    run_ids = []
+    for m in available_models:
+        print(m)
+        runs = list_runs_model_name_get(m)
+        print(runs)
+        run_ids.extend(runs)
+
+    results = []
+    for id_ in run_ids:
+        results.append(run_status_run_idget(id_))
+    
+    return results
 
 
 def update_run_status(RunID):

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -165,15 +165,12 @@ def available_results_get():  # noqa: E501
     """
     run_ids = []
     for m in available_models:
-        print(m)
         runs = list_runs_model_name_get(m)
-        print(runs)
         run_ids.extend(runs)
 
     results = []
     for id_ in run_ids:
-        results.append(run_status_run_idget(id_))
-    
+        results.append(run_results_run_idget(id_))
     return results
 
 

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -251,6 +251,23 @@ paths:
       tags:
       - execution
       x-openapi-router-controller: openapi_server.controllers.execution_controller
+  /available_results:
+    get:
+      description: Return a list of all available run results.
+      operationId: available_results_get
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/RunResults'
+                type: array
+          description: SUCCESS
+      summary: Obtain a list of run results
+      tags:
+      - execution
+      x-openapi-router-controller: openapi_server.controllers.execution_controller
 components:
   schemas:
     ModelName:

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -220,7 +220,22 @@ paths:
               schema:
                 type: "array"
                 items:
-                  $ref: '#/components/schemas/RunID'   
+                  $ref: '#/components/schemas/RunID'
+  /available_results:
+    get:
+      tags:
+      - "execution"
+      summary: "Obtain a list of run results"
+      description: "Return a list of all available run results."
+      responses:
+        200:
+          description: "SUCCESS"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: '#/components/schemas/RunResults'                   
 
 components:
   securitySchemes:


### PR DESCRIPTION
## What's New

This PR incorporates an `/available_results` endpoint. A `GET` to this endpoint returns an array of all available run results. This is accomplished by:

1. Use the list of `available_models` hardcoded at the top of the `execution_controller`
2. Iterate over this list of models, calling `/list_runs` for each to obtain a list of `run_ids` for all models.
3. Use the list of `run_ids` to pull the run results from `/run_results`.
4. Return the full array of run results

## Issues

This endpoint is challenging to test locally because the internal calls that are made (see above) pull information from Redis. Additionally, the `/run_results` endpoint relies on lower level calls to the model Docker containers. So, the containers associated with the runs found in Redis must be available on the test machine.