### PR TITLE
DSSAT integration into MaaS

### DIFF
--- a/DSSAT-Integration/et_docker.json
+++ b/DSSAT-Integration/et_docker.json
@@ -29,6 +29,9 @@
 		"fen_tot": 100.0,
 		"fertilizers": "split_fert_dap_percent::$fen_tot::2::0::50::30::50"
 	},
+	"dssat": {
+		"executable": "/app/dssat47/dscsm047"
+	},
 	"analytics_setup": {
 		"per_pixel_prefix":"pp"
 	},

--- a/DSSAT-Integration/maas_install.sh
+++ b/DSSAT-Integration/maas_install.sh
@@ -1,0 +1,13 @@
+# create DSSAT directory 
+mkdir ~/dssat-docker
+cd ~/dssat-docker
+
+# download data file
+wget https://world-modelers.s3.amazonaws.com/data/ethdata.tar.xz
+
+# download config file
+wget https://raw.githubusercontent.com/WorldModelers/ModelService/master/DSSAT-Integration/et_docker.json
+
+# create data volume
+docker run -v /data/ETH -v $PWD:/userdata --name ethdata debian:stable-slim /bin/bash
+docker run --rm --volumes-from ethdata -v ${PWD}:/userdata debian:stable-slim bash -c "apt-get update && apt-get install xz-utils && cd /data/ETH && tar xJvf /userdata/ethdata.tar.xz"

--- a/DSSAT-Integration/maas_install.sh
+++ b/DSSAT-Integration/maas_install.sh
@@ -1,6 +1,6 @@
 # create DSSAT directory 
-mkdir ~/dssat-docker
-cd ~/dssat-docker
+mkdir ~/dssat
+cd ~/dssat
 
 # download data file
 wget https://world-modelers.s3.amazonaws.com/data/ethdata.tar.xz

--- a/DSSAT-Integration/maas_install.sh
+++ b/DSSAT-Integration/maas_install.sh
@@ -11,3 +11,6 @@ wget https://raw.githubusercontent.com/WorldModelers/ModelService/master/DSSAT-I
 # create data volume
 docker run -v /data/ETH -v $PWD:/userdata --name ethdata debian:stable-slim /bin/bash
 docker run --rm --volumes-from ethdata -v ${PWD}:/userdata debian:stable-slim bash -c "apt-get update && apt-get install xz-utils && cd /data/ETH && tar xJvf /userdata/ethdata.tar.xz"
+
+# pull Docker image
+docker pull cvillalobosuf/dssat-pythia:develop

--- a/REST-Server/config.ini
+++ b/REST-Server/config.ini
@@ -15,6 +15,9 @@ PROVENANCE_ID = e8287ea4-e6f2-47aa-8bfc-0c22852735c8
 [FSC]
 OUTPUT_PATH = /tmp/fsc/outputs
 
+[DSSAT]
+OUTPUT_PATH = /home/ubuntu/dssat
+
 [MALNUTRITION]
 INSTALL_PATH = /home/ubuntu/ModelService/Kimetrica-Integration/darpa
 S3_CRED_PATH = /home/ubuntu/.aws

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -7,7 +7,7 @@ from openapi_server.models.run_status import RunStatus  # noqa: E501
 from openapi_server import util
 from openapi_server.kimetrica import KiController
 from openapi_server.fsc import FSCController
-from openapi_server.fsc import DSSATController
+from openapi_server.dssat import DSSATController
 
 import json
 from hashlib import sha256
@@ -41,6 +41,9 @@ def list_runs_model_name_get(ModelName):  # noqa: E501
 
     :rtype: List[str]
     """
+    if ModelName.lower() == 'fsc' or ModelName.lower() == 'dssat':
+        ModelName = ModelName.upper()
+
     if not r.exists(ModelName):
         return []
     else:

--- a/REST-Server/openapi_server/dssat.py
+++ b/REST-Server/openapi_server/dssat.py
@@ -7,6 +7,7 @@ import shutil
 import time
 import logging
 import boto3
+import json
 
 class DSSATController(object):
     """
@@ -29,10 +30,33 @@ class DSSATController(object):
 
         logging.basicConfig(level=logging.INFO)
 
+
+    def update_config(self):
+        """
+        Update et_docker.json file with user-submitted config
+        """
+        with open(f"{self.result_path}/et_docker.json", "r") as f:
+            config = json.loads(f.read())
+            f.close()
+
+        # If a number of samples is provided, use that
+        if self.model_config["samples"] > 0:
+            config["sample"] = self.model_config["samples"]
+        else:
+            # Otherwise, remove the `sample` key and run the 
+            # entire region (Ethiopia)
+            config.pop("sample")
+
+        with open(f"{self.result_path}/et_docker.json", "w") as f:
+            f.write(json.dumps(config))
+            f.close()
+
+
     def run_model(self):
         """
         Run DSSAT model inside Docker container
         """
+        self.update_config()
         self.model = self.containers.run(self.dssat, 
                                          volumes=self.volumes, 
                                          volumes_from=self.volumes_from,

--- a/REST-Server/openapi_server/dssat.py
+++ b/REST-Server/openapi_server/dssat.py
@@ -1,0 +1,76 @@
+import docker
+import re
+import configparser
+import redis
+import os
+import shutil
+import time
+import logging
+import boto3
+
+class DSSATController(object):
+    """
+    A controller to manage FSC model execution.
+    """
+
+    def __init__(self, model_config, output_path):
+        self.model_config = model_config
+        self.client = docker.from_env()
+        self.containers = self.client.containers
+        self.dssat = 'cvillalobosuf/dssat-pythia:develop'
+        self.result_path = output_path
+        self.result_name = self.model_config['run_id']             
+        self.bucket = "world-modelers"
+        self.key = f"results/dssat_model/{self.result_name}.zip"
+        self.entrypoint=f"/app/pythia.sh --all /userdata/et_docker.json"
+        self.volumes = {self.result_path: {'bind': '/userdata', 'mode': 'rw'}}
+        self.volumes_from = "ethdata"
+        self.mgmts = ["maize_irrig","maize_rf_0N","maize_rf_highN","maize_rf_lowN"]
+
+        logging.basicConfig(level=logging.INFO)
+
+    def run_model(self):
+        """
+        Run DSSAT model inside Docker container
+        """
+        self.model = self.containers.run(self.dssat, 
+                                         volumes=self.volumes, 
+                                         volumes_from=self.volumes_from,
+                                         entrypoint=self.entrypoint,
+                                         detach=True)
+        return self.model
+
+
+    def model_logs(self):
+        """
+        Return model logs
+        """
+        model_logs = self.model.logs()
+        model_logs_decoded = model_logs.decode('utf-8')
+        return model_logs_decoded
+    
+    
+    def storeResults(self):
+        out = f"{self.result_path}/out"
+        result = f"{self.result_path}/{self.result_name}"
+        exists = os.path.isdir(out)
+        logging.info(exists)
+        if exists:
+            # Make results for run_id
+            os.mkdir(f"{self.result_path}/{self.result_name}")
+
+            # Copy pp_* files to results directory
+            for m in self.mgmts:
+                shutil.copy(f"{self.result_path}/out/eth_docker/test/{m}/pp_{m}.csv",
+                            f"{result}/pp_{m}.csv")
+            shutil.make_archive(result, 'zip', result)            
+            session = boto3.Session(profile_name="wmuser")
+            s3 = session.client('s3')
+            s3.upload_file(f"{result}.zip", 
+                           self.bucket, 
+                           f"{self.key}", 
+                           ExtraArgs={'ACL':'public-read'})
+            logging.info(f'Results stored at : https://s3.amazonaws.com/world-modelers/{self.key}')
+            return "SUCCESS"
+        else:
+            return result

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -1,5 +1,4 @@
 # Model Execution
-
 Models can be executed using the `/run_model` endpoint. To do this, you must provide a valid JSON configuration. Each model has a unique configuration that can be provided. Below are example configurations for each model.
 
 ## Contents
@@ -19,6 +18,8 @@ Models can be executed using the `/run_model` endpoint. To do this, you must pro
 ```
 
 ### Kimetrica Malnutrition Model
+The percentage of rainfall can be specified for this model by providing a `float` based on the following scale: `0` is no rainfall, `1` is the same as the recorded amount, `2` is 2 times the recorded amount, etc.
+
 ```
 {
    "config":{
@@ -29,6 +30,7 @@ Models can be executed using the `/run_model` endpoint. To do this, you must pro
 ```
 
 ### Food Shocks Cascade Model
+Information about the specific parameters for FSC can be found [here.](https://github.com/WorldModelers/ModelService/blob/dssat/FSC-Integration/FSC-metadata.yaml#L306-L328)
 
 ```
 {
@@ -36,7 +38,6 @@ Models can be executed using the `/run_model` endpoint. To do this, you must pro
       "country":"USA",
       "fractional_reserve_access":0.8,
       "production_decrease":0.2,
-      "run_id":"cf49488892ea86c77f0f0a4176e73cfa112b52db9126d9236db9f4d3e0e21a17",
       "year":2005
    },
    "name":"FSC"
@@ -44,7 +45,6 @@ Models can be executed using the `/run_model` endpoint. To do this, you must pro
 ```
 
 ### DSSAT
-
 Note that `samples` denotes the number of pixel predictions DSSAT will make. Setting `samples` to `0` returns the entire geography (all Ethiopia) which is quite large.
 
 ```

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -1,0 +1,57 @@
+# Model Execution
+
+Models can be executed using the `/run_model` endpoint. To do this, you must provide a valid JSON configuration. Each model has a unique configuration that can be provided. Below are example configurations for each model.
+
+## Contents
+
+- [Kimetrica Population Model](#kimetrica-population-model)
+- [Kimetrica Malnutrition Model](#kimetrica-malnutrition-model)
+- [Food Shocks Cascade Model](#food-shocks-cascade-model)
+- [DSSAT](#DSSAT)
+
+### Kimetrica Population Model
+
+```
+{
+  "config": {},
+  "name": "population_model"
+}
+```
+
+### Kimetrica Malnutrition Model
+```
+{
+   "config":{
+      "percent_of_normal_rainfall":100.0
+   },
+   "name":"malnutrition_model"
+}
+```
+
+### Food Shocks Cascade Model
+
+```
+{
+   "config":{
+      "country":"USA",
+      "fractional_reserve_access":0.8,
+      "production_decrease":0.2,
+      "run_id":"cf49488892ea86c77f0f0a4176e73cfa112b52db9126d9236db9f4d3e0e21a17",
+      "year":2005
+   },
+   "name":"FSC"
+}
+```
+
+### DSSAT
+
+Note that `samples` denotes the number of pixel predictions DSSAT will make. Setting `samples` to `0` returns the entire geography (all Ethiopia) which is quite large.
+
+```
+{
+   "config":{
+      "samples":10
+   },
+   "name":"DSSAT"
+}
+```

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -30,7 +30,7 @@ The percentage of rainfall can be specified for this model by providing a `float
 ```
 
 ### Food Shocks Cascade Model
-Information about the specific parameters for FSC can be found [here.](https://github.com/WorldModelers/ModelService/blob/dssat/FSC-Integration/FSC-metadata.yaml#L306-L328)
+Information about the specific parameters for FSC can be found [here.](https://github.com/WorldModelers/ModelService/blob/master/FSC-Integration/FSC-metadata.yaml#L306-L328)
 
 ```
 {


### PR DESCRIPTION
## What's New

* Added `dssat.py` controller to execute DSSAT via Docker
* Added `maas_install.sh` shell script for setting up DSSAT on a server
* Updated `config.ini` with an output path for DSSAT
* Updated `execution_controller.py` to handle running DSSAT 

## How to Test
 
You first need to build the DSSAT directory and data volume using the `maas_install.sh` script. Then you should  You can run DSSAT by sending a config to the `/run_model` endpoint. You should send a config that includes the key `samples` which represents the number of samples to run. If set to `0` this will run the entire country of Ethiopia:

```
{
  "config": {"samples": 15},
  "name": "DSSAT"
}
```
