### PR TITLE
DSSAT integration updates

### DIFF
--- a/DSSAT-Integration/et_docker.json
+++ b/DSSAT-Integration/et_docker.json
@@ -5,8 +5,8 @@
 	"weatherDir": "/data/ETH/weathers",
 	"threads": 4,
 	"cores": 8,
-	"sample": 10,
 	"ghr_root":"/data/ETH/base/GHR",
+	"sample": 10,
 	"default_setup": {
 		"template": "ETHI8402.SNX",
 		"sites": "xy_from_vector::/data/ETH/shapes/Five_arcmin_pt_Eth.shp",
@@ -33,7 +33,8 @@
 		"executable": "/app/dssat47/dscsm047"
 	},
 	"analytics_setup": {
-		"per_pixel_prefix":"pp"
+		"per_pixel_prefix":"pp",
+		"singleOutput": true
 	},
 	"runs": [
 		{

--- a/REST-Server/openapi_server/dssat.py
+++ b/REST-Server/openapi_server/dssat.py
@@ -22,7 +22,7 @@ class DSSATController(object):
         self.result_path = output_path
         self.result_name = self.model_config['run_id']             
         self.bucket = "world-modelers"
-        self.key = f"results/dssat_model/{self.result_name}.zip"
+        self.key = f"results/dssat_model/{self.result_name}.csv"
         self.entrypoint=f"/app/pythia.sh --all /userdata/et_docker.json"
         self.volumes = {self.result_path: {'bind': '/userdata', 'mode': 'rw'}}
         self.volumes_from = "ethdata"
@@ -83,14 +83,13 @@ class DSSATController(object):
             # Make results for run_id
             os.mkdir(f"{self.result_path}/{self.result_name}")
 
-            # Copy pp_* files to results directory
-            for m in self.mgmts:
-                shutil.copy(f"{self.result_path}/out/eth_docker/test/{m}/pp_{m}.csv",
-                            f"{result}/pp_{m}.csv")
-            shutil.make_archive(result, 'zip', result)            
+            # Copy pp.csv file to results directory
+
+            shutil.copy(f"{self.result_path}/out/eth_docker/test/pp.csv",
+                        f"{result}.csv")
             session = boto3.Session(profile_name="wmuser")
             s3 = session.client('s3')
-            s3.upload_file(f"{result}.zip", 
+            s3.upload_file(f"{result}.csv", 
                            self.bucket, 
                            f"{self.key}", 
                            ExtraArgs={'ACL':'public-read'})


### PR DESCRIPTION
## What's New
The current version of DSSAT now produces a single output file, instead of 4. Subsequently, MaaS produces a single `.csv` file pushed to S3 instead of a `.zip` file compressing 4 outputs. 

# Notes
This includes a minor update to `et_docker.json` but is mostly changes to `dssat.py` dealing with file output routing.