### PR TITLE
DSSAT start year/number years parameters

### DIFF
--- a/REST-Server/openapi_server/dssat.py
+++ b/REST-Server/openapi_server/dssat.py
@@ -57,7 +57,27 @@ class DSSATController(object):
         if self.model_config["management_practice"] == "combined":
             config["analytics_setup"]["singleOutput"] = True
         else:
-            config["analytics_setup"]["singleOutput"] = False        
+            config["analytics_setup"]["singleOutput"] = False
+
+        # Update start year and number of years (if set in the user config)
+        if "start_year" in self.model_config:
+            start_year = int(self.model_config["start_year"])
+            config["default_setup"]["startYear"] = start_year
+
+            # We only bother setting number of years *if* start_year was specified
+            if "number_years" in self.model_config:
+                number_years = int(self.model_config["number_years"])
+                # ensure that the number of years to run does not exceed 2018
+                if start_year + number_years > 2018:
+                    number_years = 2018 - start_year
+            else:
+                number_years = 2018 - start_year
+            config["default_setup"]["nyers"] = number_years
+
+        # Otherwise default to a 1984 start year and run through 2018
+        else:
+            config["default_setup"]["startYear"] = 1984
+            config["default_setup"]["nyers"] = 34
 
         with open(f"{self.result_path}/et_docker.json", "w") as f:
             f.write(json.dumps(config))
@@ -69,6 +89,7 @@ class DSSATController(object):
         Run DSSAT model inside Docker container
         """
         self.update_config()
+        time.sleep(3)
         self.model = self.containers.run(self.dssat, 
                                          volumes=self.volumes, 
                                          volumes_from=self.volumes_from,

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -56,10 +56,14 @@ Note that `samples` denotes the number of pixel predictions DSSAT will make. Set
 5. `maize_rf_0N`: retrieve a single output `.csv` for a subsistence management practice
 6. `maize_rf_lowN`: retrieve a single output `.csv` for a low nitrogen management practice
 
+The earliest possible `start_year` is 1984. You may run DSSAT through 2018; if `start_year` is specified but `number_years` is not then the default will be to run from the specified `start_year` through 2018. If `start_year + number_years > 2018` it will default to running through 2018. If `start_year` is not specified then DSSAT will default to running from 1984 through 2018.
+
 ```
 {
    "config":{
       "samples":10,
+      "start_year": 2015,
+      "number_years": 2,
       "management_practice": "maize_rf_highN"
    },
    "name":"DSSAT"


### PR DESCRIPTION
## What's new
This PR includes updates to `dssat.py` which allows the user to submit the `start_year` for running DSSAT (defaults to 1984) and the `number_years` to run DSSAT (defaults to `2018 - start_year`).

This is documented in the `model-execution` docs. A sample configuration would look like:

```
{
   "config":{
      "samples":10,
      "start_year": 2015,
      "number_years": 2,
      "management_practice": "maize_rf_highN"
   },
   "name":"DSSAT"
}
```

## TODO
Though DSSAT will run with these parameters, it is not clear that the output actually reflects these parameters. @frostbytten should be consulted to ensure that the outputs are as expected when DSSAT is parameterized by start year/number of years.