### PR TITLE
Readable model names

### DIFF
--- a/Atlas-Integration/Atlas-MINT.ipynb
+++ b/Atlas-Integration/Atlas-MINT.ipynb
@@ -1,0 +1,272 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Registers Models to MINT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure MINT client:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mint_client\n",
+    "from mint_client.rest import ApiException\n",
+    "import yaml\n",
+    "from pprint import pprint\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Log in success! Token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjb20uemFsYW5kby5jb25uZXhpb24iLCJpYXQiOjE1Njk1MjY4NDIsImV4cCI6MTYyOTUyNjg0Miwic3ViIjoibW9kZWxzZXJ2aWNlIn0.Wz9hYNYO5Hisx4Nb4yz0k9HFqnM7uinv1HJfg6ddFbE\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.UserApi()\n",
+    "configuration = mint_client.Configuration()\n",
+    "\n",
+    "username = 'modelservice' # str | The user name for login\n",
+    "password = 'development' # str | The password for login in clear text\n",
+    "user = mint_client.User(username=username, password=password) # User | Created user object\n",
+    "\n",
+    "try:\n",
+    "    # Logs user into the system\n",
+    "    configuration.access_token = api_instance.login_user(username, password)\n",
+    "    print(\"Log in success! Token: %s\\n\" % configuration.access_token)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling UserApi->login_user: %s\\n\" % e)\n",
+    "\n",
+    "request_headers = {\n",
+    "    'Content-Type': \"application/json\",\n",
+    "    'X-Api-Key': configuration.access_token\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Asset Wealth Model in MINT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"asset-wealth-model-metadata.yaml\", 'r') as stream:\n",
+    "    model = yaml.safe_load(stream)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model['label'] = model.pop('name')\n",
+    "model['hasModelCategory'] = model.pop('category')\n",
+    "model['hasSoftwareVersion'] = [{'id': model.pop('version'),\n",
+    "                               'type': ['http://ontosoft.org/software#SoftwareVersion',\n",
+    "                                    'https://w3id.org/mint/modelCatalog#ModelVersion']}]\n",
+    "model['description'] = model['description'].split('\\n')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'created'\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "# create an instance of the API class\n",
+    "\n",
+    "try:\n",
+    "    # Create a model\n",
+    "    api_instance.create_model(model)\n",
+    "    pprint(\"created\")\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->create_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Consumption Model in MINT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"consumption-model-metadata.yaml\", 'r') as stream:\n",
+    "    model = yaml.safe_load(stream)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model['label'] = model.pop('name')\n",
+    "model['hasModelCategory'] = model.pop('category')\n",
+    "model['hasSoftwareVersion'] = [{'id': model.pop('version'),\n",
+    "                               'type': ['http://ontosoft.org/software#SoftwareVersion',\n",
+    "                                    'https://w3id.org/mint/modelCatalog#ModelVersion']}]\n",
+    "model['description'] = model['description'].split('\\n')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'created'\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "# create an instance of the API class\n",
+    "\n",
+    "try:\n",
+    "    # Create a model\n",
+    "    api_instance.create_model(model)\n",
+    "    pprint(\"created\")\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->create_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Helper functions (for testing):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "GET MODEL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_name='SOME_MODEL_ID'\n",
+    "try:\n",
+    "    # Get a Model\n",
+    "    api_response = api_instance.get_model(id_name, username=username)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->get_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DELETE MODEL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # Delete a Model\n",
+    "    api_instance.delete_model('SOME_MODEL_ID')\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->delete_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LIST MODELS:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "try:\n",
+    "    # List All models\n",
+    "    api_response = api_instance.get_models(username=username)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->get_models: %s\\n\" % e)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Atlas-Integration/asset-wealth-model-metadata.yaml
+++ b/Atlas-Integration/asset-wealth-model-metadata.yaml
@@ -1,0 +1,9 @@
+id: asset_wealth_model
+name: Asset Wealth Model
+description: |
+  This model uses remote sensing imagery to predict asset wealth.
+version: 'asset_wealth_model_1'
+category:
+  - Demographic
+  - Socioeconomic
+  - Economic

--- a/Atlas-Integration/consumption-model-metadata.yaml
+++ b/Atlas-Integration/consumption-model-metadata.yaml
@@ -1,0 +1,9 @@
+id: consumption_model
+name: Consumption Model
+description: |
+  This model uses remote sensing imagery to predict consumption.
+version: 'consumption_model_1'
+category:
+  - Demographic
+  - Socioeconomic
+  - Economic

--- a/CHIRPS-Integration/CHIRPS-MINT.ipynb
+++ b/CHIRPS-Integration/CHIRPS-MINT.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Registers Models to MINT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure MINT client:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mint_client\n",
+    "from mint_client.rest import ApiException\n",
+    "import yaml\n",
+    "from pprint import pprint\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Log in success! Token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjb20uemFsYW5kby5jb25uZXhpb24iLCJpYXQiOjE1Njk1MjcwNzMsImV4cCI6MTYyOTUyNzA3Mywic3ViIjoibW9kZWxzZXJ2aWNlIn0.Bz3Hhun2lDkwRWcjlwwyu2rlO0JpK_t21bblK2izgb4\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.UserApi()\n",
+    "configuration = mint_client.Configuration()\n",
+    "\n",
+    "username = 'modelservice' # str | The user name for login\n",
+    "password = 'development' # str | The password for login in clear text\n",
+    "user = mint_client.User(username=username, password=password) # User | Created user object\n",
+    "\n",
+    "try:\n",
+    "    # Logs user into the system\n",
+    "    configuration.access_token = api_instance.login_user(username, password)\n",
+    "    print(\"Log in success! Token: %s\\n\" % configuration.access_token)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling UserApi->login_user: %s\\n\" % e)\n",
+    "\n",
+    "request_headers = {\n",
+    "    'Content-Type': \"application/json\",\n",
+    "    'X-Api-Key': configuration.access_token\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create CHIRPS Model in MINT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"chirps-model-metadata.yaml\", 'r') as stream:\n",
+    "    model = yaml.safe_load(stream)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model['label'] = model.pop('name')\n",
+    "model['hasModelCategory'] = model.pop('category')\n",
+    "model['hasSoftwareVersion'] = [{'id': model.pop('version'),\n",
+    "                               'type': ['http://ontosoft.org/software#SoftwareVersion',\n",
+    "                                    'https://w3id.org/mint/modelCatalog#ModelVersion']}]\n",
+    "model['description'] = model['description'].split('\\n')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'created'\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "# create an instance of the API class\n",
+    "\n",
+    "try:\n",
+    "    # Create a model\n",
+    "    api_instance.create_model(model)\n",
+    "    pprint(\"created\")\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->create_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Helper functions (for testing):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "GET MODEL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_name='SOME_MODEL_ID'\n",
+    "try:\n",
+    "    # Get a Model\n",
+    "    api_response = api_instance.get_model(id_name, username=username)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->get_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DELETE MODEL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # Delete a Model\n",
+    "    api_instance.delete_model('SOME_MODEL_ID')\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->delete_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LIST MODELS:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "try:\n",
+    "    # List All models\n",
+    "    api_response = api_instance.get_models(username=username)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->get_models: %s\\n\" % e)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/CHIRPS-Integration/CHIRPS-model-metadata.yaml
+++ b/CHIRPS-Integration/CHIRPS-model-metadata.yaml
@@ -1,0 +1,7 @@
+id: CHIRPS
+name: Climate Hazards Group InfraRed Precipitation with Station Data
+description: |
+  Climate Hazards Group InfraRed Precipitation with Station data (CHIRPS) is a 35+ year quasi-global rainfall data set. Spanning 50°S-50°N (and all longitudes) and ranging from 1981 to near-present, CHIRPS incorporates our in-house climatology, CHPclim, 0.05° resolution satellite imagery, and in-situ station data to create gridded rainfall time series for trend analysis and seasonal drought monitoring.
+version: 'chirps_model_1'
+category:
+  - Climate

--- a/DSSAT-Integration/DSSAT-MINT.ipynb
+++ b/DSSAT-Integration/DSSAT-MINT.ipynb
@@ -1,0 +1,282 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Registers Models to MINT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure MINT client:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mint_client\n",
+    "from mint_client.rest import ApiException\n",
+    "import yaml\n",
+    "from pprint import pprint\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Log in success! Token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjb20uemFsYW5kby5jb25uZXhpb24iLCJpYXQiOjE1Njk1MjcxOTIsImV4cCI6MTYyOTUyNzE5Miwic3ViIjoibW9kZWxzZXJ2aWNlIn0.MUI0KCgOwDvo1NaArjeXVJRM4sDJX7cAXjyD35jraeg\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.UserApi()\n",
+    "configuration = mint_client.Configuration()\n",
+    "\n",
+    "username = 'modelservice' # str | The user name for login\n",
+    "password = 'development' # str | The password for login in clear text\n",
+    "user = mint_client.User(username=username, password=password) # User | Created user object\n",
+    "\n",
+    "try:\n",
+    "    # Logs user into the system\n",
+    "    configuration.access_token = api_instance.login_user(username, password)\n",
+    "    print(\"Log in success! Token: %s\\n\" % configuration.access_token)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling UserApi->login_user: %s\\n\" % e)\n",
+    "\n",
+    "request_headers = {\n",
+    "    'Content-Type': \"application/json\",\n",
+    "    'X-Api-Key': configuration.access_token\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create DSSAT Model in MINT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"DSSAT-metadata.yaml\", 'r') as stream:\n",
+    "    model_full = yaml.safe_load(stream)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = {'label': model_full[\"name\"],\n",
+    "         ''}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model['label'] = model.pop('name')\n",
+    "model['hasModelCategory'] = model.pop('category')\n",
+    "model['hasSoftwareVersion'] = [{'id': model.pop('version'),\n",
+    "                               'type': ['http://ontosoft.org/software#SoftwareVersion',\n",
+    "                                    'https://w3id.org/mint/modelCatalog#ModelVersion']}]\n",
+    "model['description'] = model['description'].split('\\n')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'created'\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "# create an instance of the API class\n",
+    "\n",
+    "try:\n",
+    "    # Create a model\n",
+    "    api_instance.create_model(model)\n",
+    "    pprint(\"created\")\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->create_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Consumption Model in MINT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"consumption-model-metadata.yaml\", 'r') as stream:\n",
+    "    model = yaml.safe_load(stream)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model['label'] = model.pop('name')\n",
+    "model['hasModelCategory'] = model.pop('category')\n",
+    "model['hasSoftwareVersion'] = [{'id': model.pop('version'),\n",
+    "                               'type': ['http://ontosoft.org/software#SoftwareVersion',\n",
+    "                                    'https://w3id.org/mint/modelCatalog#ModelVersion']}]\n",
+    "model['description'] = model['description'].split('\\n')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'created'\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "# create an instance of the API class\n",
+    "\n",
+    "try:\n",
+    "    # Create a model\n",
+    "    api_instance.create_model(model)\n",
+    "    pprint(\"created\")\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->create_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Helper functions (for testing):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "GET MODEL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_name='SOME_MODEL_ID'\n",
+    "try:\n",
+    "    # Get a Model\n",
+    "    api_response = api_instance.get_model(id_name, username=username)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->get_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DELETE MODEL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # Delete a Model\n",
+    "    api_instance.delete_model('SOME_MODEL_ID')\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->delete_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LIST MODELS:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "try:\n",
+    "    # List All models\n",
+    "    api_response = api_instance.get_models(username=username)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->get_models: %s\\n\" % e)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/DSSAT-Integration/DSSAT-model-metadata.yaml
+++ b/DSSAT-Integration/DSSAT-model-metadata.yaml
@@ -1,0 +1,7 @@
+id: DSSAT
+name: Decision Support System for Agrotechnology Transfer
+description: |
+  The Decision Support System for Agrotechnology Transfer (DSSAT) comprises dynamic crop growth simulation model for over 40 crops. The model simulates growth development; and yield as a function of the soil-plant-atmosphere dynamics.
+version: 'DSSAT_4.7'
+category:
+  - Agriculture

--- a/FSC-Integration/FSC-model-metadata.yaml
+++ b/FSC-Integration/FSC-model-metadata.yaml
@@ -1,0 +1,7 @@
+id: FSC
+name: Food Shocks Cascade Model
+description: |
+  The Food Shocks Cascade Model (FSC) is a simple agent-based network model that computes chain-reactions due to negative production anomalies based on dynamic food balance sheets at the country level.
+version: 'FSC_0.1'
+category:
+  - Economic

--- a/Kimetrica-Integration/Kimetrica-MINT.ipynb
+++ b/Kimetrica-Integration/Kimetrica-MINT.ipynb
@@ -1,0 +1,278 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Registers Models to MINT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure MINT client:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mint_client\n",
+    "from mint_client.rest import ApiException\n",
+    "import yaml\n",
+    "from pprint import pprint\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Log in success! Token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjb20uemFsYW5kby5jb25uZXhpb24iLCJpYXQiOjE1Njk1MjUxMjYsImV4cCI6MTYyOTUyNTEyNiwic3ViIjoibW9kZWxzZXJ2aWNlIn0.dX-CYQU1V4sZz26nXK8ZFJjXYMwY_NdVGKz24khLwGs\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.UserApi()\n",
+    "configuration = mint_client.Configuration()\n",
+    "\n",
+    "username = 'modelservice' # str | The user name for login\n",
+    "password = 'development' # str | The password for login in clear text\n",
+    "user = mint_client.User(username=username, password=password) # User | Created user object\n",
+    "\n",
+    "try:\n",
+    "    # Logs user into the system\n",
+    "    configuration.access_token = api_instance.login_user(username, password)\n",
+    "    print(\"Log in success! Token: %s\\n\" % configuration.access_token)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling UserApi->login_user: %s\\n\" % e)\n",
+    "\n",
+    "request_headers = {\n",
+    "    'Content-Type': \"application/json\",\n",
+    "    'X-Api-Key': configuration.access_token\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Malnutrition Model in MINT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"malnutrition-model-metadata.yaml\", 'r') as stream:\n",
+    "    model = yaml.safe_load(stream)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model['label'] = model.pop('name')\n",
+    "model['hasDocumentation'] = [model.pop('website')]\n",
+    "model['hasModelCategory'] = model.pop('category')\n",
+    "model.pop('maintainer')\n",
+    "model.pop('author')\n",
+    "model['hasSoftwareVersion'] = [{'id': model.pop('version'),\n",
+    "                               'type': ['http://ontosoft.org/software#SoftwareVersion',\n",
+    "                                    'https://w3id.org/mint/modelCatalog#ModelVersion']}]\n",
+    "model['description'] = model['description'].split('\\n')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'created'\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "# create an instance of the API class\n",
+    "\n",
+    "try:\n",
+    "    # Create a model\n",
+    "    api_instance.create_model(model)\n",
+    "    pprint(\"created\")\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->create_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Population Model in MINT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"population-model-metadata.yaml\", 'r') as stream:\n",
+    "    model = yaml.safe_load(stream)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model['label'] = model.pop('name')\n",
+    "model['hasDocumentation'] = [model.pop('website')]\n",
+    "model['hasModelCategory'] = model.pop('category')\n",
+    "model.pop('maintainer')\n",
+    "model.pop('author')\n",
+    "model['hasSoftwareVersion'] = [{'id': model.pop('version'),\n",
+    "                               'type': ['http://ontosoft.org/software#SoftwareVersion',\n",
+    "                                    'https://w3id.org/mint/modelCatalog#ModelVersion']}]\n",
+    "model['description'] = model['description'].split('\\n')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'created'\n"
+     ]
+    }
+   ],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "# create an instance of the API class\n",
+    "\n",
+    "try:\n",
+    "    # Create a model\n",
+    "    api_instance.create_model(model)\n",
+    "    pprint(\"created\")\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->create_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Helper functions (for testing):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "GET MODEL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_name='SOME_MODEL_ID'\n",
+    "try:\n",
+    "    # Get a Model\n",
+    "    api_response = api_instance.get_model(id_name, username=username)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->get_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DELETE MODEL:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # Delete a Model\n",
+    "    api_instance.delete_model('SOME_MODEL_ID')\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->delete_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LIST MODELS:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))\n",
+    "try:\n",
+    "    # List All models\n",
+    "    api_response = api_instance.get_models(username=username)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelApi->get_models: %s\\n\" % e)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Kimetrica-Integration/malnutrition-model-metadata.yaml
+++ b/Kimetrica-Integration/malnutrition-model-metadata.yaml
@@ -1,0 +1,15 @@
+id: malnutrition_model
+name: Malnutrition Model
+description: >
+  Currently, the malnutrition model takes the following input variables CHIRPS, Consumer Price Index(CPI), population, cereal production per capita, consumption expenditure,Normalized Difference Vegetation Index (NDVI),and month to predict the malnutrition rates for Global Acute Malnutrition (GAM) and Severe Acute Malnutrition (SAM). According to World Health Organization (WHO) guideline, GAM and SAM are defined as weight-for-height z-score below -2, and weight-for-height z-score below -3, respectively. By this definition, GAM includes all categories of malnutrition.
+maintainer:
+  name: Jenny Yu
+  email: jenny.yu@kimetrica.com
+author:
+  - name: Jenny Yu
+    email: jenny.yu@kimetrica.com
+version: 'malnutrition_model_1'
+website: https://gitlab.kimetrica.com/DARPA/darpa/tree/master/models/malnutrition_model
+category:
+  - Demographic
+  - Economic

--- a/Kimetrica-Integration/population-model-metadata.yaml
+++ b/Kimetrica-Integration/population-model-metadata.yaml
@@ -1,0 +1,17 @@
+id: population_model
+name: Population Model
+description: |
+  The population model is grounded on a method called Component Analysis (or Component Method) 1, which takes into account Crude Birth Rates (CBR), Crude Death Rates (CDR), and migration rates (inmigration and outmigration). Any of these rates may change in a linear or non-linear fashion.
+  popt = popt-1 + popt-1 * CBRt*(1 + birth_rate_fct) - popt-1 * CDRt *(1 + death_rate_fct) + Immigrationt- Outmigrationt
+  In this equaiton, death/birth_rate fct is applied to the nominal growth rates. It is used for sensitivity studies of changes in the growth rate. For example, if one uses a birth_rate_fct of 0.1 this will boost the nominal growth rates by 10%. These variables are put in place to account for any possible bias in the census data.
+maintainer:
+  name: Jenny Yu
+  email: jenny.yu@kimetrica.com
+author:
+  - name: Jenny Yu
+    email: jenny.yu@kimetrica.com
+version: 'population_model_1'
+website: https://gitlab.kimetrica.com/DARPA/darpa/tree/master/models/population_model
+category:
+  - Demographic
+  - Socioeconomic

--- a/REST-Server/openapi_server/models/model.py
+++ b/REST-Server/openapi_server/models/model.py
@@ -15,11 +15,13 @@ class Model(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, name=None, versions=None, maintainer=None, description=None, category=None):  # noqa: E501
+    def __init__(self, name=None, label=None, versions=None, maintainer=None, description=None, category=None):  # noqa: E501
         """Model - a model defined in OpenAPI
 
         :param name: The name of this Model.  # noqa: E501
         :type name: str
+        :param label: The label of this Model.  # noqa: E501
+        :type label: str
         :param versions: The versions of this Model.  # noqa: E501
         :type versions: List[str]
         :param maintainer: The maintainer of this Model.  # noqa: E501
@@ -31,6 +33,7 @@ class Model(Model):
         """
         self.openapi_types = {
             'name': str,
+            'label': str,
             'versions': List[str],
             'maintainer': str,
             'description': str,
@@ -39,6 +42,7 @@ class Model(Model):
 
         self.attribute_map = {
             'name': 'name',
+            'label': 'label',
             'versions': 'versions',
             'maintainer': 'maintainer',
             'description': 'description',
@@ -46,6 +50,7 @@ class Model(Model):
         }
 
         self._name = name
+        self._label = label
         self._versions = versions
         self._maintainer = maintainer
         self._description = description
@@ -86,6 +91,31 @@ class Model(Model):
             raise ValueError("Invalid value for `name`, must not be `None`")  # noqa: E501
 
         self._name = name
+
+    @property
+    def label(self):
+        """Gets the label of this Model.
+
+        The human readable name of the model  # noqa: E501
+
+        :return: The label of this Model.
+        :rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """Sets the label of this Model.
+
+        The human readable name of the model  # noqa: E501
+
+        :param label: The label of this Model.
+        :type label: str
+        """
+        if label is None:
+            raise ValueError("Invalid value for `label`, must not be `None`")  # noqa: E501
+
+        self._label = label
 
     @property
     def versions(self):

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -327,6 +327,7 @@ components:
         - LATEST
         name: FSC
         description: FSC single country shock configuration.
+        label: label
         category:
         - Agriculture
         - Economic
@@ -335,6 +336,9 @@ components:
         name:
           description: A model's name
           example: FSC
+          type: string
+        label:
+          description: The human readable name of the model
           type: string
         versions:
           description: Latest model version
@@ -363,6 +367,7 @@ components:
           type: array
       required:
       - description
+      - label
       - maintainer
       - name
       type: object

--- a/REST-Server/openapi_server/util.py
+++ b/REST-Server/openapi_server/util.py
@@ -185,7 +185,7 @@ def _get_model(ModelName, MINTconfiguration, MINTusername):
         api_response = api_instance.get_model(ModelName, username=username)
         model = {
                 'name': api_response.id,
-                'label': api_response.label
+                'label': api_response.label,
                 'description': api_response.description,
                 'maintainer': '',
                 'category': api_response.has_model_category,

--- a/REST-Server/openapi_server/util.py
+++ b/REST-Server/openapi_server/util.py
@@ -185,6 +185,7 @@ def _get_model(ModelName, MINTconfiguration, MINTusername):
         api_response = api_instance.get_model(ModelName, username=username)
         model = {
                 'name': api_response.id,
+                'label': api_response.label
                 'description': api_response.description,
                 'maintainer': '',
                 'category': api_response.has_model_category,

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -289,10 +289,14 @@ components:
       - "name"
       - "description"
       - "maintainer"
+      - "label"
       description: "An object defining high-level metadata about a model"
       properties:
         name:
           $ref: '#/components/schemas/ModelName'
+        label: 
+          type: "string"
+          description: "The human readable name of the model"
         versions:
           type: "array"
           items:


### PR DESCRIPTION
## What's New
This PR adds metadata files for each of the models which can be found in each `Model-Integration` directory. For each model, there is a YAML file `modelname-model-metadata.yaml` file. This contains bare bones metadata for each model so that the model can be registered to MINT. Each `Model-Integration` directory now also contains a Jupyter Notebook `ModelName-MINT.ipynb` which uses the YAML file to register the model to MINT.

Additionally, there are minor updates to the exploration controller and openapi spec to accommodate the `label` as the human readable model name.

## Benefit
Now all available models are listed in the `/list_models` endpoint. Also, each model has info available through the `/model_info` endpoint.