### PR TITLE
Run metadata

### DIFF
--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -20,6 +20,7 @@ import boto3
 import botocore
 import logging
 import os
+import time
 logging.basicConfig(level=logging.INFO)
 
 data_file_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -145,7 +146,8 @@ def run_model_post():  # noqa: E501
                    'bucket': m.bucket,
                    'key': m.key,
                    'stored': stored,
-                   'name': model_config['name']}
+                   'name': model_config['name'],
+                   'timestamp': round(time.time()*1000,0)}
         r.hmset(run_id, run_obj)        
 
     return run_id
@@ -166,6 +168,7 @@ def run_results_run_idget(RunID):  # noqa: E501
         
     run = r.hgetall(RunID)
     status = run[b'status'].decode('utf-8')
+    timestamp = run[b'timestamp'].decode('utf-8')
 
     # Only update the run status if the status is still PENDING
     if status == 'PENDING':
@@ -177,12 +180,18 @@ def run_results_run_idget(RunID):  # noqa: E501
     model_name = run[b'name'].decode('utf-8')
     output = ''
     output_config = {'config': config, 'name': model_name}
-    results = {'status': status, 'config': output_config, 'output': output}
+    results = {'status': status, 
+               'config': output_config, 
+               'output': output, 
+               'timestamp': timestamp,
+               'auth_required': False}
 
     if model_name in ['consumption_model', 'asset_wealth_model']:
         # special handler for Atlas.ai models
         URI = f"{site_url}/result_file/{RunID}.{config['format']}"
         results['output'] = URI
+        # ensure that auth_required is set to true
+        results['auth_required'] = True
         return results 
     elif status == 'SUCCESS':
         bucket = run[b'bucket'].decode('utf-8')

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -186,7 +186,7 @@ def run_results_run_idget(RunID):  # noqa: E501
 
     if b'timestamp' in run:
         timestamp = run[b'timestamp'].decode('utf-8')
-        results['timestamp'] = timestamp
+        results['timestamp'] = int(timestamp)
 
     if model_name in ['consumption_model', 'asset_wealth_model']:
         # special handler for Atlas.ai models

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -168,7 +168,6 @@ def run_results_run_idget(RunID):  # noqa: E501
         
     run = r.hgetall(RunID)
     status = run[b'status'].decode('utf-8')
-    timestamp = run[b'timestamp'].decode('utf-8')
 
     # Only update the run status if the status is still PENDING
     if status == 'PENDING':
@@ -183,8 +182,11 @@ def run_results_run_idget(RunID):  # noqa: E501
     results = {'status': status, 
                'config': output_config, 
                'output': output, 
-               'timestamp': timestamp,
                'auth_required': False}
+
+    if b'timestamp' in run:
+        timestamp = run[b'timestamp'].decode('utf-8')
+        results['timestamp'] = timestamp
 
     if model_name in ['consumption_model', 'asset_wealth_model']:
         # special handler for Atlas.ai models

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -186,7 +186,7 @@ def run_results_run_idget(RunID):  # noqa: E501
 
     if b'timestamp' in run:
         timestamp = run[b'timestamp'].decode('utf-8')
-        results['timestamp'] = int(timestamp)
+        results['timestamp'] = int(timestamp.split('.')[0])
 
     if model_name in ['consumption_model', 'asset_wealth_model']:
         # special handler for Atlas.ai models

--- a/REST-Server/openapi_server/models/run_results.py
+++ b/REST-Server/openapi_server/models/run_results.py
@@ -15,7 +15,7 @@ class RunResults(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, config=None, status=None, output=None):  # noqa: E501
+    def __init__(self, config=None, status=None, output=None, auth_required=None, timestamp=None):  # noqa: E501
         """RunResults - a model defined in OpenAPI
 
         :param config: The config of this RunResults.  # noqa: E501
@@ -24,22 +24,32 @@ class RunResults(Model):
         :type status: str
         :param output: The output of this RunResults.  # noqa: E501
         :type output: str
+        :param auth_required: The auth_required of this RunResults.  # noqa: E501
+        :type auth_required: bool
+        :param timestamp: The timestamp of this RunResults.  # noqa: E501
+        :type timestamp: int
         """
         self.openapi_types = {
             'config': ModelConfig,
             'status': str,
-            'output': str
+            'output': str,
+            'auth_required': bool,
+            'timestamp': int
         }
 
         self.attribute_map = {
             'config': 'config',
             'status': 'status',
-            'output': 'output'
+            'output': 'output',
+            'auth_required': 'auth_required',
+            'timestamp': 'timestamp'
         }
 
         self._config = config
         self._status = status
         self._output = output
+        self._auth_required = auth_required
+        self._timestamp = timestamp
 
     @classmethod
     def from_dict(cls, dikt) -> 'RunResults':
@@ -70,6 +80,8 @@ class RunResults(Model):
         :param config: The config of this RunResults.
         :type config: ModelConfig
         """
+        if config is None:
+            raise ValueError("Invalid value for `config`, must not be `None`")  # noqa: E501
 
         self._config = config
 
@@ -120,5 +132,53 @@ class RunResults(Model):
         :param output: The output of this RunResults.
         :type output: str
         """
+        if output is None:
+            raise ValueError("Invalid value for `output`, must not be `None`")  # noqa: E501
 
         self._output = output
+
+    @property
+    def auth_required(self):
+        """Gets the auth_required of this RunResults.
+
+        Does accessing this model output require authentification? True if requires auth.  # noqa: E501
+
+        :return: The auth_required of this RunResults.
+        :rtype: bool
+        """
+        return self._auth_required
+
+    @auth_required.setter
+    def auth_required(self, auth_required):
+        """Sets the auth_required of this RunResults.
+
+        Does accessing this model output require authentification? True if requires auth.  # noqa: E501
+
+        :param auth_required: The auth_required of this RunResults.
+        :type auth_required: bool
+        """
+
+        self._auth_required = auth_required
+
+    @property
+    def timestamp(self):
+        """Gets the timestamp of this RunResults.
+
+        Epoch timestamp when the model run was initiated (epoch time UTC)  # noqa: E501
+
+        :return: The timestamp of this RunResults.
+        :rtype: int
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        """Sets the timestamp of this RunResults.
+
+        Epoch timestamp when the model run was initiated (epoch time UTC)  # noqa: E501
+
+        :param timestamp: The timestamp of this RunResults.
+        :type timestamp: int
+        """
+
+        self._timestamp = timestamp

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -684,10 +684,12 @@ components:
       description: Metadata about the results of a given model run.
       example:
         output: output
+        auth_required: true
         config:
           name: FSC
           config: '{}'
         status: SUCCESS
+        timestamp: 0
       properties:
         config:
           $ref: '#/components/schemas/ModelConfig'
@@ -700,6 +702,17 @@ components:
         output:
           description: URI for accessing output (for example, on S3)
           type: string
+        auth_required:
+          description: Does accessing this model output require authentification? True if requires auth.
+          type: boolean
+        timestamp:
+          description: Epoch timestamp when the model run was initiated (epoch millis)
+          format: int32
+          type: integer
+      required:
+      - config
+      - output
+      - status
       type: object
     Error:
       description: Arbitrary error object.
@@ -722,11 +735,6 @@ components:
       type: array
     Concept:
       description: A concept and its mapping to model output variables.
-      example:
-        concept_name: precipitation
-        mappings:
-        - null
-        - null
       properties:
         concept_name:
           description: A concept's name

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -561,6 +561,10 @@ components:
     RunResults:
       type: "object"
       description: "Metadata about the results of a given model run."
+      required:
+        - "config"
+        - "status"
+        - "output"
       properties:
         config:
           $ref: "#/components/schemas/ModelConfig"
@@ -570,6 +574,12 @@ components:
         output:
           type: "string"
           description: "URI for accessing output (for example, on S3)"
+        auth_required:
+          description: "Does accessing this model output require authentification? True if requires auth."
+          type: boolean
+        timestamp:
+          description: "Epoch timestamp when the model run was initiated (epoch millis)"
+          type: integer
     Error:
       type: "object"
       description: "Arbitrary error object."
@@ -598,4 +608,4 @@ components:
         mappings:
           type: "array"
           items:
-            $ref: "#/components/schemas/ConceptMapping"      
+            $ref: "#/components/schemas/ConceptMapping"


### PR DESCRIPTION
## What's new
This PR adds two new (optional) fields to the `run results` object:

* `auth_required`: true if authorization is required (only for Atlas models currently); false for all other models. Note that this is hardcoded into the `execution_controller`.
* `timestamp`: the timestamp in epoch milliseconds when the model run was kicked off.