### PR TITLE
Fix container loading issue when model run failed.

### DIFF
--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -202,8 +202,10 @@ def run_results_run_idget(RunID):  # noqa: E501
         results['output'] = URI
         return results
     elif status == 'FAIL':
-        run_container = run[b'container']
-        run_logs = run_container.logs().decode('utf-8')
+        run_container_id = run[b'container'].decode('utf-8')
+        model_container = containers.get(run_container_id)
+        model_container.reload()
+        run_logs = model_container.logs().decode('utf-8')
         results['output'] = run_logs
     return results
 


### PR DESCRIPTION
## What's new

This PR fixes an issue for failed model runs. When the model run fails, the Docker container is now correctly reloaded and the model run logs are now set to the `output` key for the run results object. For example:

```
{
  "auth_required": false,
  "config": {
    "config": {
      "country": "GNQ",
      "fractional_reserve_access": 1.1e-9,
      "production_decrease": 0.25000000109,
      "run_id": "d7e654d3980855d097a1be4bca9e96015de1e7a772b98835ee3d548ef0b4fbb7",
      "year": 2005
    },
    "name": "FSC"
  },
  "output": "Country:  GNQ \nProduction Decrease: 25%\nFractional Reserve Access: 1.1e-07%\n\nError in if (abs(discrep) > tol) return(paste(\"Total dC + dR does not match initial shock.\",  : \n  missing value where TRUE/FALSE needed\nCalls: single_country -> sim_diagnostics\nExecution halted\n",
  "status": "FAIL",
  "timestamp": 1571044009771
}
```