### PR TITLE
CHIRPS Bounding Box and GEFS Integration

### DIFF
--- a/CHIRPS-Integration/CHIRPS-GEFS-model-metadata.yaml
+++ b/CHIRPS-Integration/CHIRPS-GEFS-model-metadata.yaml
@@ -1,0 +1,13 @@
+id: CHIRPS-GEFS
+name: Climate Hazards Group InfraRed Precipitation with Station Data Global Ensemble Forecast System
+description: |
+  NCEP’s Global Ensemble Forecast System (GEFS) is a weather forecast system that provides daily forecasts out to 16 days at 1 X 1 degree resolution at 6-hour intervals. This forecast product can be very useful to early warning famine and hydrological monitoring efforts, so the Climate Hazards Group (CHG) creates forecast precipitation fields at the dekadal (10 day) time scale and makes those available to researchers and decision makers.
+version: 'chirps_gefs_model_1'
+category:
+  - Climate
+concepts:
+  - precipitation
+  - water
+  - drought
+  - climate
+  - flooding

--- a/REST-Server/openapi_server/chirps.py
+++ b/REST-Server/openapi_server/chirps.py
@@ -2,6 +2,7 @@ import requests
 import logging
 import boto3
 import os
+from pyproj import Proj, transform
 
 class CHIRPSController(object):
     """
@@ -15,10 +16,13 @@ class CHIRPSController(object):
         self.dekad = self.model_config["dekad"]
         self.year = self.model_config["year"]
         self._type = self.model_config["_type"]
+        self.bbox = self.model_config["bbox"]
+        self.min_pt, self.max_pt = self.convert_bbox(self.bbox)
         self.url = f"http://chg-ewxtest.chg.ucsb.edu/proxies/wcsProxy.php?layerNameToUse=chirps:"\
                    f"chirps_africa_1-dekad-{self.dekad}-{self.year}_{self._type}"\
-                   f"&lowerLeftXToUse=3673536.4017755133&lowerLeftYToUse=378978.68273536063&upperRightXToUse=5341797.050557815"\
-                   f"&upperRightYToUse=1676937.5016708253&wcsURLToUse=http://chg-ewxtest.chg.ucsb.edu:8080/geoserver/wcs?&resolution"\
+                   f"&lowerLeftXToUse={self.min_pt[0]}&lowerLeftYToUse={self.min_pt[1]}"\
+                   f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
+                   f"&wcsURLToUse=http://chg-ewxtest.chg.ucsb.edu:8080/geoserver/wcs?&resolution"\
                    f"=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
         self.result_name = self.model_config['run_id']
         self.key = f"results/chirps/{self.result_name}.tiff"
@@ -35,7 +39,21 @@ class CHIRPSController(object):
         self.storeResults()
         return 'SUCCESS'
 
+
+    def convert_bbox(self, bb):
+        """
+        Convert WGS84 coordinate system to Web Mercator
+        Initial bbox is in format [xmin, ymin, xmax, ymax]. 
+        x is longitude, y is latitude.
+        Output is Web Mercator min/max points for a bounding box.
+        """
+        in_proj = Proj(init='epsg:4326')
+        out_proj = Proj(init='epsg:3857')
+        min_pt = transform(in_proj, out_proj, bb[0], bb[1])
+        max_pt = transform(in_proj, out_proj, bb[2], bb[3])
+        return min_pt, max_pt  
     
+
     def storeResults(self):
         result = f"{self.result_path}/{self.result_name}.tiff"
         exists = os.path.exists(result)

--- a/REST-Server/openapi_server/chirps.py
+++ b/REST-Server/openapi_server/chirps.py
@@ -9,7 +9,8 @@ class CHIRPSController(object):
     A controller to manage CHIRPS model execution.
     """
 
-    def __init__(self, model_config, output_path):
+    def __init__(self, name, model_config, output_path):
+        self.name = name
         self.model_config = model_config
         self.output_path = output_path
         self.bucket = "world-modelers"
@@ -24,6 +25,12 @@ class CHIRPSController(object):
                    f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
                    f"&wcsURLToUse=http://chg-ewxtest.chg.ucsb.edu:8080/geoserver/wcs?&resolution"\
                    f"=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
+        self.url_gefs = f"http://chg-ewxtest.chg.ucsb.edu/proxies/wcsProxy.php?layerNameToUse="\
+                        f"chirpsgefslast:chirpsgefslast_africa_1-dekad-{self.dekad}-{self.year}_{self._type}"\
+                        f"&lowerLeftXToUse={self.min_pt[0]}&lowerLeftYToUse={self.min_pt[1]}"\
+                        f"&upperRightXToUse={self.max_pt[0]}&upperRightYToUse={self.max_pt[1]}"\
+                        f"&wcsURLToUse=http://chg-ewxtest.chg.ucsb.edu:8080/geoserver/wcs?&resolution"\
+                        f"=0.05&srsToUse=EPSG:3857&outputSrsToUse=EPSG:4326"
         self.result_name = self.model_config['run_id']
         self.key = f"results/chirps/{self.result_name}.tiff"
         self.result_path = output_path
@@ -33,7 +40,14 @@ class CHIRPSController(object):
         """
         Obtain CHIRPS data
         """
-        data = requests.get(self.url)
+        # if CHIRPS-GEFS, use that URL
+        if self.name == 'CHIRPS-GEFS':
+            data = requests.get(self.url_gefs)
+
+        # otherwise, use CHRIPS URL 
+        else:
+            data = requests.get(self.url)
+            
         with open(f"{self.output_path}/{self.result_name}.tiff", "wb") as f:
             f.write(data.content)
         self.storeResults()

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -45,7 +45,8 @@ available_models = ['population_model',
                     'dssat',
                     'asset_wealth_model',
                     'consumption_model',
-                    'chirps']
+                    'chirps',
+                    'chirps-gefs']
 
 def list_runs_model_name_get(ModelName):  # noqa: E501
     """Obtain a list of runs for a given model
@@ -57,7 +58,7 @@ def list_runs_model_name_get(ModelName):  # noqa: E501
 
     :rtype: List[str]
     """
-    if ModelName.lower() in ['fsc','dssat','chirps']:
+    if ModelName.lower() in ['fsc','dssat','chirps','chirps-gefs']:
         ModelName = ModelName.upper()
 
     if not r.exists(ModelName):
@@ -122,9 +123,9 @@ def run_model_post():  # noqa: E501
             stored = 0 # use binary for Redis
             m = dssat  
 
-        elif model_name.lower() == 'chirps':
+        elif 'chirps' in model_name.lower():
             model_config['config']['run_id'] = run_id
-            chirps = CHIRPSController(model_config['config'], config['CHIRPS']['OUTPUT_PATH'])
+            chirps = CHIRPSController(model_name, model_config['config'], config['CHIRPS']['OUTPUT_PATH'])
             model_container = chirps.run_model()
             stored = 0 # use binary for Redis
             m = chirps
@@ -132,7 +133,7 @@ def run_model_post():  # noqa: E501
         # push the id to the model's list of runs
         r.sadd(model_name, run_id)
 
-        if model_name.lower() == 'chirps':
+        if 'chirps' in model_name.lower():
             model_container_id = 'SUCCESS'
             status = 'SUCCESS'
         else:
@@ -273,7 +274,7 @@ def update_run_status(RunID):
     model_name = run[b'name'].decode('utf-8')
 
     # if CHIRPS, do nothing!
-    if model_name.lower() == 'chirps':
+    if 'chirps' in model_name.lower():
         status = 'SUCCESS'
         return status
     

--- a/REST-Server/requirements.txt
+++ b/REST-Server/requirements.txt
@@ -9,3 +9,4 @@ mint-api==1.0.1
 boto3==1.9.120
 tox
 psycopg2
+pyproj

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -8,7 +8,7 @@ Models can be executed using the `/run_model` endpoint. To do this, you must pro
 - [Food Shocks Cascade Model](#food-shocks-cascade-model)
 - [DSSAT](#DSSAT)
 - [Atlas](#Atlas)
-- [CHIRPS](#CHIRPS)
+- [CHIRPS and CHIRPS-GEFS](#CHIRPS-and-CHIRPS-GEFS)
 
 ### Kimetrica Population Model
 
@@ -78,9 +78,9 @@ The earliest possible `start_year` is 1984. You may run DSSAT through 2018; if `
 The Atlas.ai consumption model and asset wealth model are available as runs in MaaS, but are not currently executable. The runs are static geospatially and temporally. They are called `consumption_model` and `asset_wealth_model`.
 
 
-### CHIRPS
+### CHIRPS and CHIRPS-GEFS
 
-CHIRPS weather data can be accessed by a configuration with the following three parameters:
+CHIRPS historic weather data and CHIRPS-GEFS forecasts can be accessed by a configuration with the following three parameters:
 
 `_type` should be one of `['mm_data','mm_anomaly','none_z-score']`. `mm_data` is the CHIRPS estimates of precipitation. The `mm_anomaly` provides the data value minus the mean of the entire time series up to the previous year. `none_z-score` provides the Standardized Precipitation Indexes ([SPI](https://climatedataguide.ucar.edu/climate-data/standardized-precipitation-index-spi)) of the estimates.
 
@@ -102,4 +102,6 @@ CHIRPS weather data can be accessed by a configuration with the following three 
 }
 ```
 
-> **Note**: CHIRPS is available for Ethiopia only at the moment. Data is available from 1981 through near present.
+For CHIRPS-GEFS, change the `name` parameter above from `CHIRPS` to `CHIRPS-GEFS`.
+
+> **Note**: Both CHIRPS and CHIRPS-GEFS dekads have historical records. CHIRPS dates back to 1981 and the CHIRPS-GEFS dekads back to 1985.

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -88,12 +88,15 @@ CHIRPS weather data can be accessed by a configuration with the following three 
 
 `year` is the year in `YYYY` format for the data of interest.
 
+`bbox` is the geospatial bounding box of interest. It should represent 4-elements in the WGS84 coordinate system: `[xmin, ymin, xmax, ymax]`. `x` is longitude, `y` is latitude. In other words, the coordinates of a SW point and a NE point define your region of interest.
+
 ```
 {
    "config":{
-      "_type": 'mm_data',
-      "dekad": '01',
-      "year": 2019
+      "_type": "mm_data",
+      "dekad": "01",
+      "year": 2019,
+      "bbox": [33.512234, 2.719907, 49.981710, 16.501768]
    },
    "name":"CHIRPS"
 }


### PR DESCRIPTION
## What's New

This PR adds a geo bounding box option for running CHIRPS. Instead of having a fixed geography, the user can specify a bounding box as a region of interest and receive data for that region.

Additionally, this PR adds a new model, CHIRPS-GEFS, which is the ensemble precipitation forecast from UCSB. This model has essentially the same configuration parameters as CHIRPS.

This PR includes updated model execution documentation to account for the new config parameters.

### TODO

CHIRPS-GEFS still needs to be registered to MINT so it appears as a model in MaaS.