### PR TITLE
Yield Anomalies Model Integration (PIK/LPJmL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ cd ../DSSAT-Integration
 cd ../Atlas-Integration
 ./maas_install.sh
 
-# Set up Concepts in Redis
-cd ../concepts
+# Install Yield Anomalies Model
+cd ../Yield-Anomalies-Integration
 ./maas_install.sh
 
 # HOW TO RUN

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -83,7 +83,6 @@ def run_model_post():  # noqa: E501
         model_config = ModelConfig.from_dict(connexion.request.get_json())  # noqa: E501
         model_config = model_config.to_dict()
         model_name = model_config["name"]
-        print(model_config)
 
         if model_name.lower() not in available_models:
             return 'Model Not Found', 404, {'x-error': 'not found'}

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -94,10 +94,9 @@ def run_model_post():  # noqa: E501
 
         # generate id for the model run
         run_id = sha256(json.dumps(model_config).encode('utf-8')).hexdigest()
-        print(run_id)
+
         # if run already exists and is success or pending, don't run again.
         if r.exists(run_id):
-            print("EXISTS")
             run = r.hgetall(run_id)
             status = run[b'status'].decode('utf-8')
             if status == "SUCCESS" or status == "PENDING":

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -46,7 +46,8 @@ available_models = ['population_model',
                     'asset_wealth_model',
                     'consumption_model',
                     'chirps',
-                    'chirps-gefs']
+                    'chirps-gefs',
+                    'yield_anomalies_lpjml']
 
 def list_runs_model_name_get(ModelName):  # noqa: E501
     """Obtain a list of runs for a given model
@@ -82,6 +83,7 @@ def run_model_post():  # noqa: E501
         model_config = ModelConfig.from_dict(connexion.request.get_json())  # noqa: E501
         model_config = model_config.to_dict()
         model_name = model_config["name"]
+        print(model_config)
 
         if model_name.lower() not in available_models:
             return 'Model Not Found', 404, {'x-error': 'not found'}
@@ -92,9 +94,10 @@ def run_model_post():  # noqa: E501
 
         # generate id for the model run
         run_id = sha256(json.dumps(model_config).encode('utf-8')).hexdigest()
-        
+        print(run_id)
         # if run already exists and is success or pending, don't run again.
         if r.exists(run_id):
+            print("EXISTS")
             run = r.hgetall(run_id)
             status = run[b'status'].decode('utf-8')
             if status == "SUCCESS" or status == "PENDING":

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -21,6 +21,7 @@ import botocore
 import logging
 import os
 import time
+from collections import OrderedDict
 logging.basicConfig(level=logging.INFO)
 
 data_file_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -90,6 +91,9 @@ def run_model_post():  # noqa: E501
         # if Atlas model, do nothing
         if model_name in ['consumption_model','asset_wealth_model']:
             return 'Atlas.ai models are not currently executable.', 400, {'x-error': 'not supported'}
+        
+        if model_name == 'yield_anomalies_lpjml':
+            model_config = util.sortOD(OrderedDict(model_config))
 
         # generate id for the model run
         run_id = sha256(json.dumps(model_config).encode('utf-8')).hexdigest()

--- a/REST-Server/openapi_server/util.py
+++ b/REST-Server/openapi_server/util.py
@@ -7,6 +7,8 @@ import requests
 import json
 from uuid import UUID
 
+from collections import OrderedDict
+
 import mint_client
 from mint_client.rest import ApiException
 
@@ -557,3 +559,12 @@ def format_model(m):
              'maintainer': f"{m['maintainer']['name']}, {m['maintainer']['email']}",
              'version': m['versions']}
     return model        
+
+def sortOD(od):
+    res = OrderedDict()
+    for k, v in sorted(od.items()):
+        if isinstance(v, dict):
+            res[k] = sortOD(v)
+        else:
+            res[k] = v
+    return res    

--- a/Yield-Anomalies-Integration/README.md
+++ b/Yield-Anomalies-Integration/README.md
@@ -1,0 +1,3 @@
+# Yield Anomalies Model (LPJmL)
+
+Running `maas_install.sh` directly invokes `yield_anomalies_data.py`. This file establishes model runs for the 180 available yield anomalies model runs provided by PIK. This script assumes that these runs are already stored in S3 at `world-modelers/results/yield_anomalies_model`.

--- a/Yield-Anomalies-Integration/maas_install.sh
+++ b/Yield-Anomalies-Integration/maas_install.sh
@@ -1,0 +1,2 @@
+# run Yield Anomalies Model setup script from this directory
+python yield_anomalies_data.py

--- a/Yield-Anomalies-Integration/yield_anomalies_data.py
+++ b/Yield-Anomalies-Integration/yield_anomalies_data.py
@@ -39,19 +39,22 @@ def gen_merged(crop, irrig, nit):
 def gen_run(crop, irrig, nit, output, stat=None):
     model_name = 'yield_anomalies_lpjml'
     model_config = {
+                    'config': {
                       "crop": crop,
                       "irrigation": irrig,
                       "nitrogen": nit,
+                    },
+                    'name': model_name
                    }
 
     if stat == None:
-        model_config["area"] = "merged"
+        model_config["config"]["area"] = "merged"
     else:
-        model_config["area"] = "global"
-        model_config["statistic"] = stat
+        model_config["config"]["area"] = "global"
+        model_config["config"]["statistic"] = stat
 
     run_id = sha256(json.dumps(model_config).encode('utf-8')).hexdigest()
-    
+    print(model_config)
     # Add to model set in Redis
     r.sadd(model_name, run_id)
     
@@ -68,6 +71,9 @@ def gen_run(crop, irrig, nit, output, stat=None):
     r.hmset(run_id, run_obj)
 
 if __name__ == "__main__":
+
+    # Wipe runs for the model
+    r.delete('yield_anomalies_lpjml')
 
     for crop in crops:
         for irrig in irrigation:

--- a/Yield-Anomalies-Integration/yield_anomalies_data.py
+++ b/Yield-Anomalies-Integration/yield_anomalies_data.py
@@ -3,6 +3,7 @@ import redis
 import configparser
 from hashlib import sha256
 import json
+from collections import OrderedDict
 
 config = configparser.ConfigParser()
 config.read('../REST-Server/config.ini')
@@ -53,6 +54,8 @@ def gen_run(crop, irrig, nit, output, stat=None):
         model_config["config"]["area"] = "global"
         model_config["config"]["statistic"] = stat
 
+    model_config =sortOD(OrderedDict(model_config))
+
     run_id = sha256(json.dumps(model_config).encode('utf-8')).hexdigest()
     print(model_config)
     # Add to model set in Redis
@@ -69,6 +72,16 @@ def gen_run(crop, irrig, nit, output, stat=None):
     run_obj['config'] = json.dumps(run_obj['config'])
     
     r.hmset(run_id, run_obj)
+
+
+def sortOD(od):
+    res = OrderedDict()
+    for k, v in sorted(od.items()):
+        if isinstance(v, dict):
+            res[k] = sortOD(v)
+        else:
+            res[k] = v
+    return res    
 
 if __name__ == "__main__":
 

--- a/Yield-Anomalies-Integration/yield_anomalies_data.py
+++ b/Yield-Anomalies-Integration/yield_anomalies_data.py
@@ -1,0 +1,82 @@
+import os
+import redis
+import configparser
+from hashlib import sha256
+import json
+
+config = configparser.ConfigParser()
+config.read('../REST-Server/config.ini')
+
+r = redis.Redis(host=config['REDIS']['HOST'],
+                port=config['REDIS']['PORT'],
+                db=config['REDIS']['DB'])
+
+bucket = 'world-modelers'
+
+crops = ['wheat', 'maize', 'millet']
+irrigation = ['LIM', 'NO', 'POT'] 
+nitrogen = ['LIM', 'LIM_p25', 'LIM_p50', 'UNLIM']
+stats = ['mean', 'std', 'pctl,5', 'pctl,95']
+
+def gen_global(crop, irrig, nit, stat):
+    if '_' in nit:
+        inc = nit.split('_')[1] + '_'
+        nit = nit.split('_')[0]
+    else:
+        inc = ''
+    output = f"global_anomalies_{crop}_{irrig}_IRRIGATION_{nit}_NITROGEN_{inc}{stat}_REFLIM_IRRIGATION_REFLIM_NITROGEN.tif"
+    return output
+
+def gen_merged(crop, irrig, nit):
+    if '_' in nit:
+        inc = nit.split('_')[1] + '_'
+        nit = nit.split('_')[0]
+    else:
+        inc = ''    
+    output = f"merged_national_crop_anomalies_{irrig}_IRRIGATION_{nit}_NITROGEN_{inc}REFLIM_IRRIGATION_REFLIM_NITROGEN_{crop}_aggregated.txt"
+    return output
+
+def gen_run(crop, irrig, nit, output, stat=None):
+    model_name = 'yield_anomalies_lpjml'
+    model_config = {
+                      "crop": crop,
+                      "irrigation": irrig,
+                      "nitrogen": nit,
+                   }
+
+    if stat == None:
+        model_config["area"] = "merged"
+    else:
+        model_config["area"] = "global"
+        model_config["statistic"] = stat
+
+    run_id = sha256(json.dumps(model_config).encode('utf-8')).hexdigest()
+    
+    # Add to model set in Redis
+    r.sadd(model_name, run_id)
+    
+    run_obj = {'status': 'SUCCESS',
+     'name': model_name,
+     'config': model_config,
+     'bucket': bucket,
+     'key': f"results/yield_anomalies_model/{output}"
+    }
+
+    run_obj['config']['run_id'] = run_id
+    run_obj['config'] = json.dumps(run_obj['config'])
+    
+    r.hmset(run_id, run_obj)
+
+if __name__ == "__main__":
+
+    for crop in crops:
+        for irrig in irrigation:
+            for nit in nitrogen:
+                # Generate merged runs
+                output = gen_merged(crop, irrig, nit)
+                gen_run(crop, irrig, nit, output)
+
+                for stat in stats:
+                    # Generate global runs
+                    output = gen_global(crop, irrig, nit, stat)
+                    gen_run(crop, irrig, nit, output, stat)

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -9,6 +9,7 @@ Models can be executed using the `/run_model` endpoint. To do this, you must pro
 - [DSSAT](#DSSAT)
 - [Atlas](#Atlas)
 - [CHIRPS and CHIRPS-GEFS](#CHIRPS-and-CHIRPS-GEFS)
+- [Yield Anomalies (LPJmL)](#Yield-Anomalies-(LPJmL))
 
 ### Kimetrica Population Model
 
@@ -105,3 +106,33 @@ CHIRPS historic weather data and CHIRPS-GEFS forecasts can be accessed by a conf
 For CHIRPS-GEFS, change the `name` parameter above from `CHIRPS` to `CHIRPS-GEFS`.
 
 > **Note**: Both CHIRPS and CHIRPS-GEFS dekads have historical records. CHIRPS dates back to 1981 and the CHIRPS-GEFS dekads back to 1985.
+
+
+### Yield Anomalies (LPJmL)
+
+* `crop`: choose the crop of interest. It should be one of `[millet, maize, wheat]`
+* `irrigation`: choose the irrigation level. It should be one of `[LIM, NO, POT]`. These correspond to:
+   * `NO`: no irrigation anywhere. Crops are rain-fed only. This can be considered as a "what-if irrigation failed scenario".
+   * `LIM`: irrigation is applied on crop-specific areas equipped for irrigation. Irrigation water withdrawal is limited to water available in surface water bodies. As a result, it is possible that irrigation demand cannot be fulfilled completely in some grid cells if demand is higher than supply.
+   * `POT`: uses the same irrigated areas as LIM_IRRIGATION, but allows for withdrawals to exceed water available in surface water bodies. As a result, irrigated crops should not experience water stress.
+* `nitrogen`: choose the nitrogen level. It should be one of `[LIM, LIM_p25, LIM_p50, UNLIM]`. These correspond to:
+      * `LIM`: country- and crop-type-specific amounts of N fertilizer to crops. The dataset is from GGCMI (the Global Gridded Crop Model Inter-comparison within AgMIP) and describes fertilizer application levels around the year 2000.
+      * `LIM_p25`: same as `LIM`, but with 25% more fertilizer in all cells where N>0. That is, cells without fertilization around 2000 in our data set do also not receive fertilizer in this scenario.
+      * `LIM_p50`: similar to _p25, but with 50% more N.
+      * `UNLIM`: extremely high N rates in all cells such that there should be no N limitation of crop growth. There are no negative effects of too much nitrogen on plant growth in our model (but there will be increased leaching and outgassing).
+* `area`: either `global` (global pixel tif file) or `merged` (a txt file aggregated to the country level)
+* `statistic`: *only provide if `area=global`*. Select the statistical aggregation over possible future climate realizations which can be any of `["mean", "std", "pctl,5", "pctl,95"]` for the mean, standard deviation, 5th percentile or 95th percentile. These four measures reflect the uncertainty of the climate forecasts starting in May 2018.
+
+```
+{
+   "config":{
+      "crop":"millet",
+      "irrigation":"POT",
+      "nitrogen":"UNLIM",
+      "area":"global",
+      "statistic":"pctl,95"
+   },
+   "name":"yield_anomalies_lpjml"
+}
+```
+

--- a/metadata/models/yield-anomalies-model-metadata.yaml
+++ b/metadata/models/yield-anomalies-model-metadata.yaml
@@ -1,0 +1,28 @@
+id: yield_anomalies_lpjml
+label: Global and national yield anomalies for wheat, maize and millet based on LPJmL
+description: >
+  We use LPJmL, a well-established dynamic global vegetation, hydrology and crop-growth model,
+  to simulate wheat, maize and millet yield anomalies for 2018 based on climate, soil conditions and
+  management regimes. Observed weather data are fed into the model until April 30, 2018;
+  afterwards, to simulate the uncertainty of operational forecasts, weather data is sourced from the
+  portion May 01-Dec 31 from the previous years (1984-2017). The crop model runs on a global grid
+  with 0.5° size in latitude and longitude.
+
+  We provide yield anomalies as deviation from the mean of 2013-2017 as simulated by LPJmL. The
+  data is available on a global grid and as nationally aggregated anomalies. Apart from a default
+  simulation, assuming the same management in 2018 as for the previous years, we provide
+  alternative intervention scenarios that assume different irrigation levels, more nitrogen input, or
+  both. In total, there are 3 (crops) * 12 (scenarios) = 36 hypothetical back-casting simulations. Each
+  of these scenarios is calculated for each of the 34 different 2018 climate realizations.
+versions: 
+  - 'yield_anomalies_lpjml_backcasting_2018'
+maintainer:
+  name: Bernhard Schauberger
+  email: schauber@pik-potsdam.de
+category:
+  - Agriculture
+concepts:
+  - food_production
+  - farming
+  - food_security
+  - food_insecurity  


### PR DESCRIPTION
## What's New

This PR contains the addition of the `Global and national yield anomalies for wheat, maize and millet based on LPJmL` model. This includes adding metadata for this model, updating the execution controller to handle the model, and adding an install/setup script for the model. This script, found in `/Yield-Anomalies-Integration`, assumes that the model outputs (which are currently static) are already in S3. For each model output, it creates a model configuration and pushes this configuration into Redis.