### PR TITLE
Results filter

### DIFF
--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -253,7 +253,7 @@ def available_results_get(model=None, size=None):
 
     # model provided but no size
     elif model != None and size == None:
-        runs = list_runs_model_name_get(m)
+        runs = list_runs_model_name_get(model)
         run_ids.extend(runs)
 
     # size provided but no model

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -22,6 +22,7 @@ import logging
 import os
 import time
 from collections import OrderedDict
+from random import choice as randomchoice
 logging.basicConfig(level=logging.INFO)
 
 data_file_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
@@ -229,17 +230,47 @@ def run_status_run_idget(RunID):  # noqa: E501
     return update_run_status(RunID)
 
 
-def available_results_get():  # noqa: E501
+def available_results_get(model=None, size=None):
     """Obtain a list of run results
 
     Return a list of all available run results. # noqa: E501
 
-
     :rtype: List[RunResults]
     """
+    
+    print(model)
+    print(size)
+
     run_ids = []
-    for m in available_models:
+
+    # no model or size
+    if model == None and size == None:
+        for m in available_models:
+            if m in ['fsc','dssat','chirps','chirps-gefs']:
+                m = m.upper()
+            runs = list_runs_model_name_get(m)
+            run_ids.extend(runs)
+
+    # model provided but no size
+    elif model != None and size == None:
         runs = list_runs_model_name_get(m)
+        run_ids.extend(runs)
+
+    # size provided but no model
+    elif model == None and size != None:
+        n = 1
+        while n <= size:
+            m = randomchoice(available_models)
+            if m in ['fsc','dssat','chirps','chirps-gefs']:
+                m = m.upper()
+            rand_run = r.srandmember(m)
+            if rand_run != None:
+                run_ids.append(rand_run.decode('utf-8'))
+                n+=1
+
+    # model provided and size provided
+    elif model != None and size != None:
+        runs = [run.decode('utf-8') for run in list(r.srandmember(model, size))]
         run_ids.extend(runs)
 
     results = []

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -230,14 +230,14 @@ def run_status_run_idget(RunID):  # noqa: E501
     return update_run_status(RunID)
 
 
-def available_results_get(model=None, size=None):
+def available_results_get(model_name=None, size=None):
     """Obtain a list of run results
 
     Return a list of all available run results. # noqa: E501
 
     :rtype: List[RunResults]
     """
-    
+    model = model_name
     print(model)
     print(size)
 

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -241,6 +241,9 @@ def available_results_get(ModelName=None, size=None):
     print(model)
     print(size)
 
+    if model.lower() not in available_models:
+        return 'Model Not Found', 404, {'x-error': 'not found'}
+
     run_ids = []
 
     # no model or size

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -241,8 +241,9 @@ def available_results_get(ModelName=None, size=None):
     print(model)
     print(size)
 
-    if model.lower() not in available_models:
-        return 'Model Not Found', 404, {'x-error': 'not found'}
+    if model != None:
+        if model.lower() not in available_models:
+            return 'Model Not Found', 404, {'x-error': 'not found'}
 
     run_ids = []
 

--- a/REST-Server/openapi_server/controllers/execution_controller.py
+++ b/REST-Server/openapi_server/controllers/execution_controller.py
@@ -230,14 +230,14 @@ def run_status_run_idget(RunID):  # noqa: E501
     return update_run_status(RunID)
 
 
-def available_results_get(model_name=None, size=None):
+def available_results_get(ModelName=None, size=None):
     """Obtain a list of run results
 
     Return a list of all available run results. # noqa: E501
 
     :rtype: List[RunResults]
     """
-    model = model_name
+    model = ModelName
     print(model)
     print(size)
 

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -299,7 +299,7 @@ paths:
       - description: A model name
         explode: true
         in: query
-        name: model
+        name: ModelName
         required: false
         schema:
           $ref: '#/components/schemas/ModelName'

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -295,6 +295,24 @@ paths:
     get:
       description: Return a list of all available run results.
       operationId: available_results_get
+      parameters:
+      - description: A model name
+        explode: true
+        in: query
+        name: model
+        required: false
+        schema:
+          $ref: '#/components/schemas/ModelName'
+        style: form
+      - description: The maximum number of results to return.
+        explode: true
+        in: query
+        name: size
+        required: false
+        schema:
+          format: int32
+          type: integer
+        style: form
       responses:
         200:
           content:

--- a/REST-Server/openapi_server/test/test_execution_controller.py
+++ b/REST-Server/openapi_server/test/test_execution_controller.py
@@ -19,7 +19,7 @@ class TestExecutionController(BaseTestCase):
 
         Obtain a list of run results
         """
-        query_string = [('model', 'model_example'),
+        query_string = [('model_name', 'model_name_example'),
                         ('size', 56)]
         response = self.client.open(
             '/available_results',

--- a/REST-Server/openapi_server/test/test_execution_controller.py
+++ b/REST-Server/openapi_server/test/test_execution_controller.py
@@ -19,9 +19,12 @@ class TestExecutionController(BaseTestCase):
 
         Obtain a list of run results
         """
+        query_string = [('model', 'model_example'),
+                        ('size', 56)]
         response = self.client.open(
             '/available_results',
-            method='GET')
+            method='GET',
+            query_string=query_string)
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 
@@ -36,13 +39,13 @@ class TestExecutionController(BaseTestCase):
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 
-    def test_result_file_run_idget(self):
-        """Test case for result_file_run_idget
+    def test_result_file_result_file_name_get(self):
+        """Test case for result_file_result_file_name_get
 
         Obtain the result file for a given model run.
         """
         response = self.client.open(
-            '/result_file/{RunID}'.format(run_id='run_id_example'),
+            '/result_file/{ResultFileName}'.format(result_file_name='result_file_name_example'),
             method='GET')
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -264,7 +264,7 @@ paths:
       description: "Return a list of all available run results."
       parameters:
       - in: query
-        name: model
+        name: ModelName
         description: "A model name"
         required: false
         schema:

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -262,6 +262,18 @@ paths:
       - "execution"
       summary: "Obtain a list of run results"
       description: "Return a list of all available run results."
+      parameters:
+      - in: query
+        name: model
+        description: "A model name"
+        required: false
+        schema:
+          $ref: "#/components/schemas/ModelName"      
+      - in: query
+        name: size
+        description: The maximum number of results to return.
+        schema:
+          type: integer
       responses:
         200:
           description: "SUCCESS"


### PR DESCRIPTION
## What's New

This PR allows a user to submit two optional query parameters to the `/available_results` endpoint:

1) `ModelName`: the name of the model to filter for
2) `size`: the maximum number of results to return

There are 4 cases:

1) Neither `ModelName` nor `size` are provided: all results are returned.
2) `ModelName` is provided but not `size`: all results for the selected model are returned.
3) `size` is provided but not `ModelName`: the number of `size` random results are returned.
4) `ModelName` and `size` are provided: up to `size` results for model `ModelName` are returned. If for example `size=100` but there are only `10` results for model `ModelName` then just `10` results are returned.