### PR TITLE
Integrated TWIST with only one allowed parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Models may be run using the `/run_model` endpoint. Descriptions of model configu
 - Atlas.ai Consumption Model
 - Atlas.ai Asset Wealth Model
 - CHIRPS
+- Yield Anomalies (LPJmL)
+- TWIST
 
 
 ### Architecture
@@ -82,6 +84,10 @@ cd ../Atlas-Integration
 
 # Install Yield Anomalies Model
 cd ../Yield-Anomalies-Integration
+./maas_install.sh
+
+# Install TWIST
+cd ../TWIST-Integration
 ./maas_install.sh
 
 # HOW TO RUN

--- a/REST-Server/config.ini
+++ b/REST-Server/config.ini
@@ -28,7 +28,10 @@ OUTPUT_PATH = /home/ubuntu/fsc/outputs
 OUTPUT_PATH = /home/ubuntu/dssat
 
 [CHIRPS]
-OUTPUT_PATH = /home/ubuntu/chirps
+OUTPUT_PATH = /home/ubuntu/CHIRPS
+
+[TWIST]
+OUTPUT_PATH = /home/ubuntu/TWIST
 
 [MALNUTRITION]
 INSTALL_PATH = /home/ubuntu/ModelService/Kimetrica-Integration/darpa

--- a/REST-Server/openapi_server/twist.py
+++ b/REST-Server/openapi_server/twist.py
@@ -1,0 +1,89 @@
+import docker
+import re
+import configparser
+import redis
+import os
+import shutil
+import time
+import logging
+import boto3
+
+class TWISTController(object):
+    """
+    A controller to manage TWIST model execution.
+    """
+
+    def __init__(self, model_config, output_path):
+        self.model_config = model_config
+        self.client = docker.from_env()
+        self.containers = self.client.containers
+        self.twist = 'wm-twist'
+        self.result_path = output_path
+        self.result_name = self.model_config['run_id']
+        self.bucket = "world-modelers"
+        self.key = f"results/twist_model/{self.result_name}.pkl"
+        self.volumes = {self.result_path: {'bind': '/twist', 'mode': 'rw'}}
+
+        logging.basicConfig(level=logging.INFO)
+
+
+    def update_config(self):
+        """
+        Update TWIST_settings.py with appropriate configuration.
+
+        Currently just allow start_year to be updated.
+
+        TODO: verify other parameters to update.
+        """
+        if "start_year" in self.model_config:
+            start_year = self.model_config["start_year"]
+        else:
+            start_year = 1975
+
+        with open(f"{self.result_path}/main/TWIST_settings.py", 'r') as file:
+            data = file.readlines()
+
+        # now change the 2nd line, note that you have to add a newline
+        data[78] = f"start_year = {start_year}\n"
+
+        # and write everything back
+        with open(f"{self.result_path}/main/TWIST_settings.py", 'w') as file:
+            file.writelines( data )
+
+
+    def run_model(self):
+        """
+        Run TWIST model inside Docker container
+        """
+        self.update_config()
+
+        self.model = self.containers.run(self.twist, 
+                                         volumes=self.volumes, 
+                                         detach=True)
+        return self.model
+
+
+    def model_logs(self):
+        """
+        Return model logs
+        """
+        model_logs = self.model.logs()
+        model_logs_decoded = model_logs.decode('utf-8')
+        return model_logs_decoded
+    
+    
+    def storeResults(self):
+        result = f"{self.result_path}/TWIST_results.pkl"
+        exists = os.path.exists(result)
+        logging.info(exists)
+        if exists:      
+            session = boto3.Session(profile_name="wmuser")
+            s3 = session.client('s3')
+            s3.upload_file(f"{result}", 
+                           self.bucket, 
+                           f"{self.key}", 
+                           ExtraArgs={'ACL':'public-read'})
+            logging.info(f'Results stored at : https://s3.amazonaws.com/world-modelers/{self.key}')
+            return "SUCCESS"
+        else:
+            return result

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -10,6 +10,7 @@ Models can be executed using the `/run_model` endpoint. To do this, you must pro
 - [Atlas](#Atlas)
 - [CHIRPS and CHIRPS-GEFS](#CHIRPS-and-CHIRPS-GEFS)
 - [Yield Anomalies (LPJmL)](#Yield-Anomalies-LPJmL)
+- [TWIST](#TWIST)
 
 ### Kimetrica Population Model
 
@@ -136,3 +137,15 @@ For CHIRPS-GEFS, change the `name` parameter above from `CHIRPS` to `CHIRPS-GEFS
 }
 ```
 
+
+### TWIST
+Currently, only the start year of the crop failure can be specified (from 1975 onward):
+
+```
+{
+   "config":{
+      "start_year":1980
+   },
+   "name":"TWIST"
+}
+```

--- a/metadata/models/TWIST-model-metadata.yaml
+++ b/metadata/models/TWIST-model-metadata.yaml
@@ -1,0 +1,18 @@
+id: TWIST
+label: Trade WIth STorage Model
+description: |
+  Trade WIth STorage (TWIST) models the impact of i) regional crop failures, ii) supply side policies (e.g., build-up of food security reserves), iii) short-term unilateral policies (e.g., export restrictions) on short term world market price variability and stocks of the main staple commodities.
+versions: 
+  - 'TWIST_0.1'
+maintainer:
+  name: Theresa falkendal
+  email: theresa.falkendal@pik-potsdam.de
+category:
+  - Economic
+  - Agriculture
+concepts:
+  - economy
+  - import
+  - export
+  - food_security
+  - crop_storage  


### PR DESCRIPTION
## What's New

This PR integrates [TWIST](https://github.com/mjpuma/TWIST-WorldModelers) into MaaS. The TWIST model is executed via a pre-built Docker container which is setup by `TWIST-Integration/maas_install.sh`. 

## Issues

1. The TWIST output is a `.pkl` file. This is stored to S3 as a `.pkl`; it is not large so could be converted to a CSV.
2. Only `start_year` can be specified as a configurable parameter. This requires input from @TheresaFalkendal to determine which parameters should be user configurable and which specific line in the [settings file](https://github.com/mjpuma/TWIST-WorldModelers/blob/master/main/TWIST_settings.py) should be accordingly changed.
3. @TheresaFalkendal should review the [metadata we show for TWIST](https://github.com/WorldModelers/ModelService/blob/TWIST/metadata/models/TWIST-model-metadata.yaml) to ensure it's accuracy.