### PR TITLE
Population Model Country Selection

### DIFF
--- a/Kimetrica-Integration/maas_install.sh
+++ b/Kimetrica-Integration/maas_install.sh
@@ -3,10 +3,11 @@ cd darpa/kiluigi
 git checkout master
 cd ..
 
-sed -i '4s/kiluigi\///g' env.example
+sed -i '7s/kiluigi\///g' env.example
 
 # NOTE - You must change the env.example CKAN creds manually right now as Kimetrica hasn't made them public.  Do this before the next step
 cp env.example kiluigi/.env
+cp docker-compose.darpa.yml kiluigi/
 cp luigi.cfg.example luigi.cfg
 cd kiluigi
 sed -i '58s/1000M/10000M/' docker-compose.yml

--- a/Model-Outputs/raster-to-csv.ipynb
+++ b/Model-Outputs/raster-to-csv.ipynb
@@ -1,0 +1,863 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "import rasterio\n",
+    "import unrasterize"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CHIRPS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raster_path = 'chirps-sample.tiff'\n",
+    "raster_data = rasterio.open(raster_path)\n",
+    "unrasterizer = unrasterize.WindowedUnrasterizer(mask_width=5, threshold=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>rainfall</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>POINT (39.01941 5.88235)</td>\n",
+       "      <td>9699.878906</td>\n",
+       "      <td>5.882349</td>\n",
+       "      <td>39.019412</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>POINT (40.01850 6.12789)</td>\n",
+       "      <td>9063.426758</td>\n",
+       "      <td>6.127887</td>\n",
+       "      <td>40.018495</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>POINT (39.91859 5.48949)</td>\n",
+       "      <td>8637.401367</td>\n",
+       "      <td>5.489489</td>\n",
+       "      <td>39.918587</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>POINT (39.66882 5.93146)</td>\n",
+       "      <td>7943.245117</td>\n",
+       "      <td>5.931457</td>\n",
+       "      <td>39.668816</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>POINT (38.96946 6.17699)</td>\n",
+       "      <td>8012.909180</td>\n",
+       "      <td>6.176994</td>\n",
+       "      <td>38.969458</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   geometry     rainfall  latitude  longitude\n",
+       "0  POINT (39.01941 5.88235)  9699.878906  5.882349  39.019412\n",
+       "1  POINT (40.01850 6.12789)  9063.426758  6.127887  40.018495\n",
+       "2  POINT (39.91859 5.48949)  8637.401367  5.489489  39.918587\n",
+       "3  POINT (39.66882 5.93146)  7943.245117  5.931457  39.668816\n",
+       "4  POINT (38.96946 6.17699)  8012.909180  6.176994  38.969458"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unrasterizer.select_representative_pixels(raster_data)\n",
+    "gdf = unrasterizer.to_geopandas(value_attribute_name='rainfall', crs=raster_data.crs)\n",
+    "gdf['latitude'] = gdf.geometry.apply(lambda x: x.bounds[1])\n",
+    "gdf['longitude'] = gdf.geometry.apply(lambda x: x.bounds[0])\n",
+    "gdf.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[['rainfall','latitude','longitude']].to_csv(\"chirps.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Flood Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raster_path = 'flood-model.tif'\n",
+    "raster_data = rasterio.open(raster_path)\n",
+    "unrasterizer = unrasterize.WindowedUnrasterizer(mask_width=1, threshold=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>flood-index</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.333333</td>\n",
+       "      <td>POINT (34.90505 6.70294)</td>\n",
+       "      <td>6.702941</td>\n",
+       "      <td>34.905052</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.666667</td>\n",
+       "      <td>POINT (34.90505 6.74461)</td>\n",
+       "      <td>6.744612</td>\n",
+       "      <td>34.905052</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.333333</td>\n",
+       "      <td>POINT (34.90505 6.73628)</td>\n",
+       "      <td>6.736277</td>\n",
+       "      <td>34.905052</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1.333333</td>\n",
+       "      <td>POINT (34.90505 6.72794)</td>\n",
+       "      <td>6.727943</td>\n",
+       "      <td>34.905052</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1.333333</td>\n",
+       "      <td>POINT (34.90505 6.71961)</td>\n",
+       "      <td>6.719609</td>\n",
+       "      <td>34.905052</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   flood-index                  geometry  latitude  longitude\n",
+       "0     1.333333  POINT (34.90505 6.70294)  6.702941  34.905052\n",
+       "1     0.666667  POINT (34.90505 6.74461)  6.744612  34.905052\n",
+       "2     1.333333  POINT (34.90505 6.73628)  6.736277  34.905052\n",
+       "3     1.333333  POINT (34.90505 6.72794)  6.727943  34.905052\n",
+       "4     1.333333  POINT (34.90505 6.71961)  6.719609  34.905052"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unrasterizer.select_representative_pixels(raster_data)\n",
+    "gdf = unrasterizer.to_geopandas(value_attribute_name='flood-index', crs=raster_data.crs)\n",
+    "gdf['latitude'] = gdf.geometry.apply(lambda x: x.bounds[1])\n",
+    "gdf['longitude'] = gdf.geometry.apply(lambda x: x.bounds[0])\n",
+    "gdf.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(518, 4)"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gdf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[['flood-index','latitude','longitude']].to_csv(\"flood-model.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Travel Time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raster_path = 'travel-time-model.tif'\n",
+    "raster_data = rasterio.open(raster_path)\n",
+    "unrasterizer = unrasterize.WindowedUnrasterizer(mask_width=50, threshold=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>travel-time</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>POINT (33.00486 7.94473)</td>\n",
+       "      <td>1658.488647</td>\n",
+       "      <td>7.944733</td>\n",
+       "      <td>33.004860</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>POINT (33.01319 7.95307)</td>\n",
+       "      <td>3241.519531</td>\n",
+       "      <td>7.953067</td>\n",
+       "      <td>33.013194</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>POINT (33.02153 7.95307)</td>\n",
+       "      <td>3590.978516</td>\n",
+       "      <td>7.953067</td>\n",
+       "      <td>33.021529</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>POINT (33.02986 7.95307)</td>\n",
+       "      <td>3826.181641</td>\n",
+       "      <td>7.953067</td>\n",
+       "      <td>33.029863</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>POINT (33.03820 7.99474)</td>\n",
+       "      <td>5105.964355</td>\n",
+       "      <td>7.994738</td>\n",
+       "      <td>33.038197</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   geometry  travel-time  latitude  longitude\n",
+       "0  POINT (33.00486 7.94473)  1658.488647  7.944733  33.004860\n",
+       "1  POINT (33.01319 7.95307)  3241.519531  7.953067  33.013194\n",
+       "2  POINT (33.02153 7.95307)  3590.978516  7.953067  33.021529\n",
+       "3  POINT (33.02986 7.95307)  3826.181641  7.953067  33.029863\n",
+       "4  POINT (33.03820 7.99474)  5105.964355  7.994738  33.038197"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unrasterizer.select_representative_pixels(raster_data)\n",
+    "gdf = unrasterizer.to_geopandas(value_attribute_name='travel-time', crs=raster_data.crs)\n",
+    "gdf['latitude'] = gdf.geometry.apply(lambda x: x.bounds[1])\n",
+    "gdf['longitude'] = gdf.geometry.apply(lambda x: x.bounds[0])\n",
+    "gdf.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(21715, 4)"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gdf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[['travel-time','latitude','longitude']].to_csv(\"travel-time.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Market Price Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raster_path = 'market-price-model.tiff'\n",
+    "raster_data = rasterio.open(raster_path)\n",
+    "unrasterizer = unrasterize.WindowedUnrasterizer(mask_width=50, threshold=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>market-price</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>POINT (26.29678 6.38370)</td>\n",
+       "      <td>12.991247</td>\n",
+       "      <td>6.383705</td>\n",
+       "      <td>26.296783</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>POINT (26.30512 6.39204)</td>\n",
+       "      <td>22.734684</td>\n",
+       "      <td>6.392036</td>\n",
+       "      <td>26.305118</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>POINT (26.31345 6.40037)</td>\n",
+       "      <td>38.973740</td>\n",
+       "      <td>6.400367</td>\n",
+       "      <td>26.313452</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>POINT (26.32179 6.40870)</td>\n",
+       "      <td>48.717171</td>\n",
+       "      <td>6.408698</td>\n",
+       "      <td>26.321786</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>POINT (26.33012 6.42536)</td>\n",
+       "      <td>58.460609</td>\n",
+       "      <td>6.425361</td>\n",
+       "      <td>26.330120</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   geometry  market-price  latitude  longitude\n",
+       "0  POINT (26.29678 6.38370)     12.991247  6.383705  26.296783\n",
+       "1  POINT (26.30512 6.39204)     22.734684  6.392036  26.305118\n",
+       "2  POINT (26.31345 6.40037)     38.973740  6.400367  26.313452\n",
+       "3  POINT (26.32179 6.40870)     48.717171  6.408698  26.321786\n",
+       "4  POINT (26.33012 6.42536)     58.460609  6.425361  26.330120"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unrasterizer.select_representative_pixels(raster_data)\n",
+    "gdf = unrasterizer.to_geopandas(value_attribute_name='market-price', crs=raster_data.crs)\n",
+    "gdf['latitude'] = gdf.geometry.apply(lambda x: x.bounds[1])\n",
+    "gdf['longitude'] = gdf.geometry.apply(lambda x: x.bounds[0])\n",
+    "gdf.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(9462, 4)"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gdf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[['market-price','latitude','longitude']].to_csv(\"market-price.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Economic Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raster_path = 'economic-model.tif'\n",
+    "raster_data = rasterio.open(raster_path)\n",
+    "unrasterizer = unrasterize.WindowedUnrasterizer(mask_width=50, threshold=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>economic-level</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.180591</td>\n",
+       "      <td>POINT (24.15490 8.39985)</td>\n",
+       "      <td>8.399848</td>\n",
+       "      <td>24.154901</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>11.668580</td>\n",
+       "      <td>POINT (24.16324 8.37485)</td>\n",
+       "      <td>8.374854</td>\n",
+       "      <td>24.163235</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>30.528280</td>\n",
+       "      <td>POINT (24.17157 8.40818)</td>\n",
+       "      <td>8.408179</td>\n",
+       "      <td>24.171569</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>36.420708</td>\n",
+       "      <td>POINT (24.17990 8.35819)</td>\n",
+       "      <td>8.358192</td>\n",
+       "      <td>24.179903</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>42.962482</td>\n",
+       "      <td>POINT (24.18824 8.37485)</td>\n",
+       "      <td>8.374854</td>\n",
+       "      <td>24.188237</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   economic-level                  geometry  latitude  longitude\n",
+       "0        2.180591  POINT (24.15490 8.39985)  8.399848  24.154901\n",
+       "1       11.668580  POINT (24.16324 8.37485)  8.374854  24.163235\n",
+       "2       30.528280  POINT (24.17157 8.40818)  8.408179  24.171569\n",
+       "3       36.420708  POINT (24.17990 8.35819)  8.358192  24.179903\n",
+       "4       42.962482  POINT (24.18824 8.37485)  8.374854  24.188237"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unrasterizer.select_representative_pixels(raster_data)\n",
+    "gdf = unrasterizer.to_geopandas(value_attribute_name='economic-level', crs=raster_data.crs)\n",
+    "gdf['latitude'] = gdf.geometry.apply(lambda x: x.bounds[1])\n",
+    "gdf['longitude'] = gdf.geometry.apply(lambda x: x.bounds[0])\n",
+    "gdf.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(12272, 4)"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gdf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[['economic-level','latitude','longitude']].to_csv(\"economic-model.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Economic Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raster_path = 'economic-model.tif'\n",
+    "raster_data = rasterio.open(raster_path)\n",
+    "unrasterizer = unrasterize.WindowedUnrasterizer(mask_width=50, threshold=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>economic-level</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.180591</td>\n",
+       "      <td>POINT (24.15490 8.39985)</td>\n",
+       "      <td>8.399848</td>\n",
+       "      <td>24.154901</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>11.668580</td>\n",
+       "      <td>POINT (24.16324 8.37485)</td>\n",
+       "      <td>8.374854</td>\n",
+       "      <td>24.163235</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>30.528280</td>\n",
+       "      <td>POINT (24.17157 8.40818)</td>\n",
+       "      <td>8.408179</td>\n",
+       "      <td>24.171569</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>36.420708</td>\n",
+       "      <td>POINT (24.17990 8.35819)</td>\n",
+       "      <td>8.358192</td>\n",
+       "      <td>24.179903</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>42.962482</td>\n",
+       "      <td>POINT (24.18824 8.37485)</td>\n",
+       "      <td>8.374854</td>\n",
+       "      <td>24.188237</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   economic-level                  geometry  latitude  longitude\n",
+       "0        2.180591  POINT (24.15490 8.39985)  8.399848  24.154901\n",
+       "1       11.668580  POINT (24.16324 8.37485)  8.374854  24.163235\n",
+       "2       30.528280  POINT (24.17157 8.40818)  8.408179  24.171569\n",
+       "3       36.420708  POINT (24.17990 8.35819)  8.358192  24.179903\n",
+       "4       42.962482  POINT (24.18824 8.37485)  8.374854  24.188237"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unrasterizer.select_representative_pixels(raster_data)\n",
+    "gdf = unrasterizer.to_geopandas(value_attribute_name='economic-level', crs=raster_data.crs)\n",
+    "gdf['latitude'] = gdf.geometry.apply(lambda x: x.bounds[1])\n",
+    "gdf['longitude'] = gdf.geometry.apply(lambda x: x.bounds[0])\n",
+    "gdf.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(12272, 4)"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gdf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf[['economic-level','latitude','longitude']].to_csv(\"economic-model.csv\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/REST-Server/openapi_server/kimetrica.py
+++ b/REST-Server/openapi_server/kimetrica.py
@@ -19,7 +19,7 @@ class KiController(object):
 				    },
                 "population_model":{
 			"key":"results/population_model/" + model_config["config"]["run_id"] + ".csv",
-                        "entrypoint":f"python run.py --bucket={self.bucket} --model_name=population_model --task_name=EstimatePopulation --result_name=final/population_estimate.csv  --key=" + "results/population_model/" + model_config["config"]["run_id"] + ".csv " + "--params country-level|" + str(model_config["config"].get("country_level",""))
+                        "entrypoint":f"python run.py --bucket={self.bucket} --model_name=population_model --task_name=EstimatePopulation --result_name=final/population_estimate.csv  --key=" + "results/population_model/" + model_config["config"]["run_id"] + ".csv " + "--params " + f"country-level|'{model_config['config'].get('country_level','Ethiopia')}'"
 				   }
         }
         config = configparser.ConfigParser()

--- a/REST-Server/openapi_server/kimetrica.py
+++ b/REST-Server/openapi_server/kimetrica.py
@@ -19,7 +19,7 @@ class KiController(object):
 				    },
                 "population_model":{
 			"key":"results/population_model/" + model_config["config"]["run_id"] + ".csv",
-                        "entrypoint":f"python run.py --bucket={self.bucket} --model_name=population_model --task_name=EstimatePopulation --result_name=final/population_estimate.csv  --key=" + "results/population_model/" + model_config["config"]["run_id"] + ".csv"
+                        "entrypoint":f"python run.py --bucket={self.bucket} --model_name=population_model --task_name=EstimatePopulation --result_name=final/population_estimate.csv  --key=" + "results/population_model/" + model_config["config"]["run_id"] + ".csv " + "--params country-level|" + str(model_config["config"].get("country_level",""))
 				   }
         }
         config = configparser.ConfigParser()

--- a/docs/model-execution.md
+++ b/docs/model-execution.md
@@ -12,10 +12,13 @@ Models can be executed using the `/run_model` endpoint. To do this, you must pro
 - [Yield Anomalies (LPJmL)](#Yield-Anomalies-LPJmL)
 
 ### Kimetrica Population Model
+The population model can be run for either Ethiopia or South Sudan by setting the `country_level` to either `Ethiopia` or `South Sudan` as shown below:
 
 ```
 {
-  "config": {},
+  "config": {
+      "country_level": "Ethiopia"
+   },
   "name": "population_model"
 }
 ```


### PR DESCRIPTION
## What's New
This PR updates the Kimetrica installation to handle changes to their Github repository (updated `Kimetrica-Integration/maas_install.sh`).

Additionally, this updates the `kimetrica.py` controller for the REST-Server to ensure that the parameter `country_level` is passed when the user runs the `population_model`. Note that if the user does not provide this parameter on `/run_model` it defaults to `Ethiopia`. The options are either `Ethiopia` or `South Sudan`.