### PR TITLE
Update /model_parameters endpoint

### DIFF
--- a/REST-Server/openapi_server/controllers/exploration_controller.py
+++ b/REST-Server/openapi_server/controllers/exploration_controller.py
@@ -187,7 +187,7 @@ def model_io_post():  # noqa: E501
             return "Exception when calling MINT API: %s\n" % e
 
 
-def model_parameters_model_name_post(ModelName):  # noqa: E501
+def model_parameters_model_name_get(ModelName):  # noqa: E501
     """Obtain information about a model&#39;s parameters.
 
     Submit a model name and receive information about the parameters used by this model. Specific parameters are used on a per-configuration basis. # noqa: E501
@@ -200,38 +200,8 @@ def model_parameters_model_name_post(ModelName):  # noqa: E501
 
     # Obtain all parameters associated with *any* configuration for 
     # the given model
-    configs = model_config_model_name_get(ModelName)
-    parameter_ids = set()
-    for c in configs:
-        for param in c['config'].get('has_parameter',[]):
-            parameter_ids.add(param['id'])
-
-    try:
-        api_instance = mint_client.ParameterApi(mint_client.ApiClient(configuration))
-        # List All Parameters
-        api_response = api_instance.get_parameters(username=username)
-        
-        parameters = []
-        for param in api_response:
-            if param.id in parameter_ids:
-                parameter = {'id': param.id,
-                             'description': param.description,
-                             'label': param.label,
-                             # need to format the following strings as they have been converted
-                             # to arrays by MINT due to duplicate entry attempts
-                             'data_type': util.format_stringed_array(param.has_data_type),
-                             'default_value': util.format_stringed_array(param.has_default_value)} 
-                             
-                             # TODO: need to implement a lookup to grab the standard name
-                             # `param.type` is an array of URIs, but does not conform
-                             # to how we should present `standard_name`s based on 
-                             # the MaaS API spec
-
-                             #'standard_name': param.type}
-                parameters.append(parameter)
-        return parameters
-    except ApiException as e:
-        print("Exception when calling ParameterApi->get_parameters: %s\n" % e)
+    m = json.loads(r.get(f'{ModelName}-meta').decode('utf-8'))
+    return util.format_parameters(m)
 
 
 def search_post():  # noqa: E501

--- a/REST-Server/openapi_server/models/parameter.py
+++ b/REST-Server/openapi_server/models/parameter.py
@@ -15,46 +15,46 @@ class Parameter(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, id=None, description=None, label=None, data_type=None, default_value=None, standard_name=None):  # noqa: E501
+    def __init__(self, name=None, description=None, type=None, default_value=None, minimum=None, maximum=None):  # noqa: E501
         """Parameter - a model defined in OpenAPI
 
-        :param id: The id of this Parameter.  # noqa: E501
-        :type id: str
+        :param name: The name of this Parameter.  # noqa: E501
+        :type name: str
         :param description: The description of this Parameter.  # noqa: E501
         :type description: str
-        :param label: The label of this Parameter.  # noqa: E501
-        :type label: str
-        :param data_type: The data_type of this Parameter.  # noqa: E501
-        :type data_type: str
+        :param type: The type of this Parameter.  # noqa: E501
+        :type type: str
         :param default_value: The default_value of this Parameter.  # noqa: E501
         :type default_value: object
-        :param standard_name: The standard_name of this Parameter.  # noqa: E501
-        :type standard_name: List[StandardName]
+        :param minimum: The minimum of this Parameter.  # noqa: E501
+        :type minimum: object
+        :param maximum: The maximum of this Parameter.  # noqa: E501
+        :type maximum: object
         """
         self.openapi_types = {
-            'id': str,
+            'name': str,
             'description': str,
-            'label': str,
-            'data_type': str,
+            'type': str,
             'default_value': object,
-            'standard_name': List[StandardName]
+            'minimum': object,
+            'maximum': object
         }
 
         self.attribute_map = {
-            'id': 'id',
+            'name': 'name',
             'description': 'description',
-            'label': 'label',
-            'data_type': 'data_type',
+            'type': 'type',
             'default_value': 'default_value',
-            'standard_name': 'standard_name'
+            'minimum': 'minimum',
+            'maximum': 'maximum'
         }
 
-        self._id = id
+        self._name = name
         self._description = description
-        self._label = label
-        self._data_type = data_type
+        self._type = type
         self._default_value = default_value
-        self._standard_name = standard_name
+        self._minimum = minimum
+        self._maximum = maximum
 
     @classmethod
     def from_dict(cls, dikt) -> 'Parameter':
@@ -68,29 +68,29 @@ class Parameter(Model):
         return util.deserialize_model(dikt, cls)
 
     @property
-    def id(self):
-        """Gets the id of this Parameter.
+    def name(self):
+        """Gets the name of this Parameter.
 
-        Identifier associated with parameter in MINT  # noqa: E501
+        The name of the parameter  # noqa: E501
 
-        :return: The id of this Parameter.
+        :return: The name of this Parameter.
         :rtype: str
         """
-        return self._id
+        return self._name
 
-    @id.setter
-    def id(self, id):
-        """Sets the id of this Parameter.
+    @name.setter
+    def name(self, name):
+        """Sets the name of this Parameter.
 
-        Identifier associated with parameter in MINT  # noqa: E501
+        The name of the parameter  # noqa: E501
 
-        :param id: The id of this Parameter.
-        :type id: str
+        :param name: The name of this Parameter.
+        :type name: str
         """
-        if id is None:
-            raise ValueError("Invalid value for `id`, must not be `None`")  # noqa: E501
+        if name is None:
+            raise ValueError("Invalid value for `name`, must not be `None`")  # noqa: E501
 
-        self._id = id
+        self._name = name
 
     @property
     def description(self):
@@ -112,60 +112,45 @@ class Parameter(Model):
         :param description: The description of this Parameter.
         :type description: str
         """
+        if description is None:
+            raise ValueError("Invalid value for `description`, must not be `None`")  # noqa: E501
 
         self._description = description
 
     @property
-    def label(self):
-        """Gets the label of this Parameter.
+    def type(self):
+        """Gets the type of this Parameter.
 
-        The name of the parameter, which should be used as a `key` within a `config` sent to the `run_model` endpoint.  # noqa: E501
+        The parameter's type  # noqa: E501
 
-        :return: The label of this Parameter.
+        :return: The type of this Parameter.
         :rtype: str
         """
-        return self._label
+        return self._type
 
-    @label.setter
-    def label(self, label):
-        """Sets the label of this Parameter.
+    @type.setter
+    def type(self, type):
+        """Sets the type of this Parameter.
 
-        The name of the parameter, which should be used as a `key` within a `config` sent to the `run_model` endpoint.  # noqa: E501
+        The parameter's type  # noqa: E501
 
-        :param label: The label of this Parameter.
-        :type label: str
+        :param type: The type of this Parameter.
+        :type type: str
         """
+        allowed_values = ["NumberParameter", "ChoiceParameter", "TimeParameter", "GeoParameter", "StringParameter"]  # noqa: E501
+        if type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `type` ({0}), must be one of {1}"
+                .format(type, allowed_values)
+            )
 
-        self._label = label
-
-    @property
-    def data_type(self):
-        """Gets the data_type of this Parameter.
-
-        The parameter's data type  # noqa: E501
-
-        :return: The data_type of this Parameter.
-        :rtype: str
-        """
-        return self._data_type
-
-    @data_type.setter
-    def data_type(self, data_type):
-        """Sets the data_type of this Parameter.
-
-        The parameter's data type  # noqa: E501
-
-        :param data_type: The data_type of this Parameter.
-        :type data_type: str
-        """
-
-        self._data_type = data_type
+        self._type = type
 
     @property
     def default_value(self):
         """Gets the default_value of this Parameter.
 
-        The parameter's default value. Type depends on the parameter's data_type  # noqa: E501
+        The parameter's default value. Type depends on the parameter's type.  # noqa: E501
 
         :return: The default_value of this Parameter.
         :rtype: object
@@ -176,7 +161,7 @@ class Parameter(Model):
     def default_value(self, default_value):
         """Sets the default_value of this Parameter.
 
-        The parameter's default value. Type depends on the parameter's data_type  # noqa: E501
+        The parameter's default value. Type depends on the parameter's type.  # noqa: E501
 
         :param default_value: The default_value of this Parameter.
         :type default_value: object
@@ -185,22 +170,47 @@ class Parameter(Model):
         self._default_value = default_value
 
     @property
-    def standard_name(self):
-        """Gets the standard_name of this Parameter.
+    def minimum(self):
+        """Gets the minimum of this Parameter.
 
+        The parameter's minimum allowed value. Type depends on the parameter's type.  # noqa: E501
 
-        :return: The standard_name of this Parameter.
-        :rtype: List[StandardName]
+        :return: The minimum of this Parameter.
+        :rtype: object
         """
-        return self._standard_name
+        return self._minimum
 
-    @standard_name.setter
-    def standard_name(self, standard_name):
-        """Sets the standard_name of this Parameter.
+    @minimum.setter
+    def minimum(self, minimum):
+        """Sets the minimum of this Parameter.
 
+        The parameter's minimum allowed value. Type depends on the parameter's type.  # noqa: E501
 
-        :param standard_name: The standard_name of this Parameter.
-        :type standard_name: List[StandardName]
+        :param minimum: The minimum of this Parameter.
+        :type minimum: object
         """
 
-        self._standard_name = standard_name
+        self._minimum = minimum
+
+    @property
+    def maximum(self):
+        """Gets the maximum of this Parameter.
+
+        The parameter's maximum allowed value. Type depends on the parameter's type.  # noqa: E501
+
+        :return: The maximum of this Parameter.
+        :rtype: object
+        """
+        return self._maximum
+
+    @maximum.setter
+    def maximum(self, maximum):
+        """Sets the maximum of this Parameter.
+
+        The parameter's maximum allowed value. Type depends on the parameter's type.  # noqa: E501
+
+        :param maximum: The maximum of this Parameter.
+        :type maximum: object
+        """
+
+        self._maximum = maximum

--- a/REST-Server/openapi_server/models/parameter.py
+++ b/REST-Server/openapi_server/models/parameter.py
@@ -15,7 +15,7 @@ class Parameter(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, name=None, description=None, type=None, default_value=None, minimum=None, maximum=None):  # noqa: E501
+    def __init__(self, name=None, description=None, type=None, default_value=None, minimum=None, maximum=None, choices=None):  # noqa: E501
         """Parameter - a model defined in OpenAPI
 
         :param name: The name of this Parameter.  # noqa: E501
@@ -30,6 +30,8 @@ class Parameter(Model):
         :type minimum: object
         :param maximum: The maximum of this Parameter.  # noqa: E501
         :type maximum: object
+        :param choices: The choices of this Parameter.  # noqa: E501
+        :type choices: List
         """
         self.openapi_types = {
             'name': str,
@@ -37,7 +39,8 @@ class Parameter(Model):
             'type': str,
             'default_value': object,
             'minimum': object,
-            'maximum': object
+            'maximum': object,
+            'choices': List
         }
 
         self.attribute_map = {
@@ -46,7 +49,8 @@ class Parameter(Model):
             'type': 'type',
             'default_value': 'default_value',
             'minimum': 'minimum',
-            'maximum': 'maximum'
+            'maximum': 'maximum',
+            'choices': 'choices'
         }
 
         self._name = name
@@ -55,6 +59,7 @@ class Parameter(Model):
         self._default_value = default_value
         self._minimum = minimum
         self._maximum = maximum
+        self._choices = choices
 
     @classmethod
     def from_dict(cls, dikt) -> 'Parameter':
@@ -214,3 +219,26 @@ class Parameter(Model):
         """
 
         self._maximum = maximum
+
+    @property
+    def choices(self):
+        """Gets the choices of this Parameter.
+
+        An array of choices available for a parameter of type ChoiceParameter  # noqa: E501
+
+        :return: The choices of this Parameter.
+        :rtype: List
+        """
+        return self._choices
+
+    @choices.setter
+    def choices(self, choices):
+        """Sets the choices of this Parameter.
+
+        An array of choices available for a parameter of type ChoiceParameter  # noqa: E501
+
+        :param choices: The choices of this Parameter.
+        :type choices: List
+        """
+
+        self._choices = choices

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -71,9 +71,9 @@ paths:
       - exploration
       x-openapi-router-controller: openapi_server.controllers.exploration_controller
   /model_parameters/{ModelName}:
-    post:
+    get:
       description: Submit a model name and receive information about the parameters used by this model. Specific parameters are used on a per-configuration basis.
-      operationId: model_parameters_model_name_post
+      operationId: model_parameters_model_name_get
       parameters:
       - description: The name of a model.
         explode: false
@@ -558,44 +558,43 @@ components:
     Parameter:
       description: A user configurable model parameter
       example:
-        data_type: string
-        description: The ISO 3 country code for the country of interest.
+        name: crop
+        description: Choose the crop of interest from one of [millet, maize, wheat].
+        maximum: 100
         default_value: USA
-        standard_name:
-        - standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-          standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-          standard_variable_name: year
-        - standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-          standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-          standard_variable_name: year
-        id: FSC-country-code
-        label: FSC simulation country
+        type: StringParameter
+        minimum: 0
       properties:
-        id:
-          description: Identifier associated with parameter in MINT
-          example: FSC-country-code
+        name:
+          description: The name of the parameter
+          example: crop
           type: string
         description:
           description: Natural language description of parameter
-          example: The ISO 3 country code for the country of interest.
+          example: Choose the crop of interest from one of [millet, maize, wheat].
           type: string
-        label:
-          description: The name of the parameter, which should be used as a `key` within a `config` sent to the `run_model` endpoint.
-          example: FSC simulation country
-          type: string
-        data_type:
-          description: The parameter's data type
-          example: string
+        type:
+          description: The parameter's type
+          enum:
+          - NumberParameter
+          - ChoiceParameter
+          - TimeParameter
+          - GeoParameter
+          - StringParameter
+          example: StringParameter
           type: string
         default_value:
-          description: The parameter's default value. Type depends on the parameter's data_type
+          description: The parameter's default value. Type depends on the parameter's type.
           example: USA
-        standard_name:
-          items:
-            $ref: '#/components/schemas/StandardName'
-          type: array
+        minimum:
+          description: The parameter's minimum allowed value. Type depends on the parameter's type.
+          example: 0
+        maximum:
+          description: The parameter's maximum allowed value. Type depends on the parameter's type.
+          example: 100
       required:
-      - id
+      - description
+      - name
       type: object
     SearchResult:
       description: The result of a search

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -563,6 +563,7 @@ components:
         maximum: 100
         default_value: USA
         type: StringParameter
+        choices: ""
         minimum: 0
       properties:
         name:
@@ -592,6 +593,9 @@ components:
         maximum:
           description: The parameter's maximum allowed value. Type depends on the parameter's type.
           example: 100
+        choices:
+          description: An array of choices available for a parameter of type ChoiceParameter
+          type: array
       required:
       - description
       - name

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -560,11 +560,14 @@ components:
       example:
         name: crop
         description: Choose the crop of interest from one of [millet, maize, wheat].
-        maximum: 100
-        default_value: USA
+        maximum: ""
+        default_value: maize
         type: StringParameter
-        choices: ""
-        minimum: 0
+        choices:
+        - millet
+        - maize
+        - wheat
+        minimum: ""
       properties:
         name:
           description: The name of the parameter
@@ -586,15 +589,17 @@ components:
           type: string
         default_value:
           description: The parameter's default value. Type depends on the parameter's type.
-          example: USA
+          example: maize
         minimum:
           description: The parameter's minimum allowed value. Type depends on the parameter's type.
-          example: 0
         maximum:
           description: The parameter's maximum allowed value. Type depends on the parameter's type.
-          example: 100
         choices:
           description: An array of choices available for a parameter of type ChoiceParameter
+          example:
+          - millet
+          - maize
+          - wheat
           type: array
       required:
       - description

--- a/REST-Server/openapi_server/test/test_exploration_controller.py
+++ b/REST-Server/openapi_server/test/test_exploration_controller.py
@@ -65,14 +65,14 @@ class TestExplorationController(BaseTestCase):
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 
-    def test_model_parameters_model_name_post(self):
-        """Test case for model_parameters_model_name_post
+    def test_model_parameters_model_name_get(self):
+        """Test case for model_parameters_model_name_get
 
         Obtain information about a model's parameters.
         """
         response = self.client.open(
             '/model_parameters/{ModelName}'.format(model_name='model_name_example'),
-            method='POST')
+            method='GET')
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 

--- a/REST-Server/openapi_server/util.py
+++ b/REST-Server/openapi_server/util.py
@@ -567,7 +567,23 @@ def format_model(m):
              'category': m['category'],
              'maintainer': f"{m['maintainer']['name']}, {m['maintainer']['email']}",
              'version': m['versions']}
-    return model        
+    return model
+
+def format_parameters(m):
+    """
+    Takes in  a model metadata JSON from Redis and formats the parameters for the MaaS API.
+    This just pops the `metadata` key and adds all its sub keys as top-level
+    keys to the parameter object.
+    """
+    p = m.get('parameters',[])
+    out_p = []
+    for p in p:
+        o_p = {'name': p['name'],
+               'description': p['description'].replace('\n','')}
+        for kk, vv in p['metadata'].items():
+            o_p[kk] = vv
+        out_p.append(o_p)
+    return out_p
 
 def sortOD(od):
     res = OrderedDict()

--- a/metadata/models/FSC-model-metadata.yaml
+++ b/metadata/models/FSC-model-metadata.yaml
@@ -24,7 +24,7 @@ outputs:
     description: Change in production levels
 
 parameters:
-  - country: 
+  - name: country
     description: Select the country for which to induce a food shock (ISO-3 format).
     metadata:
       type: ChoiceParameter

--- a/metadata/models/yield-anomalies-model-metadata.yaml
+++ b/metadata/models/yield-anomalies-model-metadata.yaml
@@ -50,9 +50,9 @@ parameters:
     metadata:
       type: ChoiceParameter
       choices:
-        - NO
-        - LIM
-        - POT
+        - "NO"
+        - "LIM"
+        - "POT"
   - name: nitrogen
     description: >
       Choose the nitrogen level. It should be one of [LIM, LIM_p25, LIM_p50, UNLIM]. 

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -482,6 +482,9 @@ components:
         maximum:
           description: "The parameter's maximum allowed value. Type depends on the parameter's type."
           example: 100
+        choices:
+          type: "array"
+          description: An array of choices available for a parameter of type ChoiceParameter
     SearchResult:
       type: "array"
       description: "The result of a search"

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -65,7 +65,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ModelIO'
   /model_parameters/{ModelName}:
-    post:
+    get:
       tags:
       - "exploration"
       summary: "Obtain information about a model's parameters."
@@ -452,31 +452,36 @@ components:
       type: "object"
       description: "A user configurable model parameter"
       required:
-        - "id"
+        - "name"
+        - "description"
       properties:
-        id:
+        name:
           type: "string"
-          description: "Identifier associated with parameter in MINT"
-          example: "FSC-country-code"
+          description: "The name of the parameter"
+          example: "crop"
         description: 
           type: "string"
           description: "Natural language description of parameter"
-          example: "The ISO 3 country code for the country of interest."
-        label:
+          example: "Choose the crop of interest from one of [millet, maize, wheat]."
+        type:
           type: "string"
-          description: "The name of the parameter, which should be used as a `key` within a `config` sent to the `run_model` endpoint."
-          example: "FSC simulation country"
-        data_type:
-          type: "string"
-          description: "The parameter's data type"
-          example: "string"
+          description: "The parameter's type"
+          example: "StringParameter"
+          enum: 
+            - NumberParameter
+            - ChoiceParameter
+            - TimeParameter
+            - GeoParameter
+            - StringParameter
         default_value:
-          description: "The parameter's default value. Type depends on the parameter's data_type"
+          description: "The parameter's default value. Type depends on the parameter's type."
           example: "USA"
-        standard_name:
-          type: "array"
-          items:
-            $ref: '#/components/schemas/StandardName'
+        minimum:
+          description: "The parameter's minimum allowed value. Type depends on the parameter's type."
+          example: 0
+        maximum:
+          description: "The parameter's maximum allowed value. Type depends on the parameter's type."
+          example: 100
     SearchResult:
       type: "array"
       description: "The result of a search"

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -475,16 +475,15 @@ components:
             - StringParameter
         default_value:
           description: "The parameter's default value. Type depends on the parameter's type."
-          example: "USA"
+          example: "maize"
         minimum:
           description: "The parameter's minimum allowed value. Type depends on the parameter's type."
-          example: 0
         maximum:
           description: "The parameter's maximum allowed value. Type depends on the parameter's type."
-          example: 100
         choices:
           type: "array"
           description: An array of choices available for a parameter of type ChoiceParameter
+          example: ["millet", "maize", "wheat"]
     SearchResult:
       type: "array"
       description: "The result of a search"


### PR DESCRIPTION
# What's New
This PR replaces fetching model parameter metadata from MINT with a direct read from the metadata that is stored in the various `{model_name}-model-metadata.yaml` files. The Open API Specification is simplified to provide a lightweight reference for the various model parameters.