### PR TITLE
Update /model_config/ endpoint to use model YAML files

### DIFF
--- a/REST-Server/openapi_server/controllers/exploration_controller.py
+++ b/REST-Server/openapi_server/controllers/exploration_controller.py
@@ -87,30 +87,8 @@ def model_config_model_name_get(ModelName):  # noqa: E501
     :rtype: ModelConfig
     """
     # get model
-    try:
-        api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))
-        model = api_instance.get_model(ModelName, username=username)
-        versions = [v['id'] for v in model.has_software_version]
-
-        # for each model version, obtain configuration ids
-        configuration_ids = []
-        api_instance = mint_client.ModelversionApi(mint_client.ApiClient(configuration))
-        for v in versions:
-            version = api_instance.get_model_version(v, username=username)
-            c_ids = [c.id for c in version.has_configuration]
-            configuration_ids.extend(c_ids)
-
-        # get configurations
-        configurations = []
-        api_instance = mint_client.ModelconfigurationApi(mint_client.ApiClient(configuration))
-        for _id in configuration_ids:
-            config = api_instance.get_model_configuraton(_id, username=username)
-            configurations.append({'name': ModelName, 'config': config.to_dict()})
-
-        return configurations
-
-    except ApiException as e:
-        return "Exception when calling MINT: %s\n" % e
+    m = json.loads(r.get(f'{ModelName}-meta').decode('utf-8'))
+    return util.format_config(m)
 
 def model_info_model_name_get(ModelName):  # noqa: E501
     """Get basic metadata information for a specified model.

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -88,9 +88,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/Parameter'
-                type: array
+                $ref: '#/components/schemas/Parameter'
           description: SUCCESS
       summary: Obtain information about a model's parameters.
       tags:
@@ -114,9 +112,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/ModelConfig'
-                type: array
+                $ref: '#/components/schemas/ModelConfig'
           description: SUCCESS
       summary: Obtain configurations for a given model.
       tags:

--- a/REST-Server/openapi_server/util.py
+++ b/REST-Server/openapi_server/util.py
@@ -585,6 +585,16 @@ def format_parameters(m):
         out_p.append(o_p)
     return out_p
 
+def format_config(m):
+    """
+    Takes in  a model metadata JSON from Redis and formats the config the MaaS API.
+    """
+    c = m.get('configuration',[])
+    out_c = {'name': m.get('id'), 'config': {}}
+    if len(c) > 0:
+        out_c['config'] = c[0]
+    return out_c
+
 def sortOD(od):
     res = OrderedDict()
     for k, v in sorted(od.items()):

--- a/metadata/models/CHIRPS-GEFS-model-metadata.yaml
+++ b/metadata/models/CHIRPS-GEFS-model-metadata.yaml
@@ -58,4 +58,10 @@ parameters:
       words, the coordinates of a SW point and a NE point define your region of interest.
     metadata:
       type: GeoParameter
-      default: [33.512234, 2.719907, 49.981710, 16.501768]  
+      default: [33.512234, 2.719907, 49.981710, 16.501768]
+
+configuration:
+  - _type: mm_data
+    dekad: 01
+    year: 2019
+    bbox: [33.512234, 2.719907, 49.981710, 16.501768]

--- a/metadata/models/CHIRPS-model-metadata.yaml
+++ b/metadata/models/CHIRPS-model-metadata.yaml
@@ -59,3 +59,9 @@ parameters:
     metadata:
       type: GeoParameter
       default: [33.512234, 2.719907, 49.981710, 16.501768]
+
+configuration:
+  - _type: mm_data
+    dekad: 01
+    year: 2019
+    bbox: [33.512234, 2.719907, 49.981710, 16.501768]      

--- a/metadata/models/DSSAT-model-metadata.yaml
+++ b/metadata/models/DSSAT-model-metadata.yaml
@@ -111,3 +111,13 @@ parameters:
     default: "05-20"
     minumum: "01-01"
     maximum: "12-31"     
+
+configuration:
+  - samples: 0
+    start_year: 2017
+    number_Years: 2
+    management_practice: combined
+    rainfall: 1
+    fertilizer: 100
+    planting_start: 03-01
+    planting_end: 05-20

--- a/metadata/models/FSC-model-metadata.yaml
+++ b/metadata/models/FSC-model-metadata.yaml
@@ -54,3 +54,9 @@ parameters:
     metadata:
       type: TimeParameter
       default: 2005
+
+configuration:
+  - country: USA
+    fractional_reserve_access: 1
+    production_decrease: 0.5
+    year: 2005

--- a/metadata/models/malnutrition-model-metadata.yaml
+++ b/metadata/models/malnutrition-model-metadata.yaml
@@ -34,3 +34,6 @@ parameters:
       minimum: 0
       maximum: 200
       default: 100
+
+configuration:
+  - percent_of_normal_rainfall: 1

--- a/metadata/models/population-model-metadata.yaml
+++ b/metadata/models/population-model-metadata.yaml
@@ -33,3 +33,6 @@ parameters:
         - Ethiopia
         - South Sudan
       default: Ethiopia
+
+configuration:
+  - country_level: Ethiopia      

--- a/metadata/models/yield-anomalies-model-metadata.yaml
+++ b/metadata/models/yield-anomalies-model-metadata.yaml
@@ -88,3 +88,10 @@ parameters:
         - std
         - pctl,5
         - pctl,95
+
+configuration:
+  - crop: maize
+    irrigation: LIM
+    nitrogen: LIM
+    area: global
+    statistic: mean

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -83,9 +83,7 @@ paths:
           content:
             application/json:
               schema:
-                type: "array"
-                items:
-                  $ref: '#/components/schemas/Parameter'               
+                $ref: '#/components/schemas/Parameter'               
   /model_config/{ModelName}:
     get:
       tags:
@@ -105,9 +103,7 @@ paths:
           content:
             application/json:
               schema:
-                type: "array"
-                items:
-                  $ref: '#/components/schemas/ModelConfig'    
+                $ref: '#/components/schemas/ModelConfig'    
   /search:
     post:
       tags: 


### PR DESCRIPTION
This PR updates the `/model_config/` endpoint to rely on a sample configuration provided in each of the `{model_name)-model-metadata.yaml` files. Each of these files has been updated to include a basic configuration. Calls to the `/model_config/` endpoint reflect the contents of these YAML files.

For example, for the `yield-anomalies-model-metadata.yaml` file, this adds a `configuration` block:

```
configuration:
  - crop: maize
    irrigation: LIM
    nitrogen: LIM
    area: global
    statistic: mean
```