### PR TITLE
Added metadata to ontologies mapper for UAZ machine reading

### DIFF
--- a/metadata/Metadata-to-Ontologies.py
+++ b/metadata/Metadata-to-Ontologies.py
@@ -1,0 +1,56 @@
+import yaml
+import glob
+
+def represent_none(self, _):
+    return self.represent_scalar('tag:yaml.org,2002:null', '')
+
+# Ensure that nulls are not dumped to yaml
+yaml.add_representer(type(None), represent_none)
+
+model_meta_files = glob.glob('models/*model*yaml')
+
+models = [{'MaaS-Models':[]}]
+variables = [{'MaaS-Variables': []}]
+parameters = [{'MaaS-Parameters': []}]
+
+for m in model_meta_files:
+    with open(m, 'r') as stream:
+        model = yaml.safe_load(stream)
+        
+    node = {'OntologyNode': None,
+            'name': model['id'],
+            'examples': [model['description'].replace('\n','')],
+            'polarity': 1.0
+           }
+
+    models[0]['MaaS-Models'].append(node)   
+    
+    for var in model['outputs']:
+        node = {'OntologyNode': None,
+                'name': var['name'],
+                'model': model['id'],                
+                'examples': [var['description'].replace('\n','')],
+                'polarity': 1.0
+               }
+        
+        variables[0]['MaaS-Variables'].append(node) 
+    
+    if 'parameters' in model:
+        for param in model['parameters']:
+            node = {'OntologyNode': None,
+                    'name': param['name'],
+                    'model': model['id'],
+                    'examples': [param['description'].replace('\n','')],
+                    'polarity': 1.0
+                   }
+
+            parameters[0]['MaaS-Parameters'].append(node)         
+
+ff = open('ontologies/MaaS-model-ontology.yaml', 'w+')
+yaml.dump(models, ff, allow_unicode=True)
+
+ff = open('ontologies/MaaS-variable-ontology.yaml', 'w+')
+yaml.dump(variables, ff, allow_unicode=True)
+
+ff = open('ontologies/MaaS-parameter-ontology.yaml', 'w+')
+yaml.dump(parameters, ff, allow_unicode=True)

--- a/metadata/ontologies/MaaS-model-ontology.yaml
+++ b/metadata/ontologies/MaaS-model-ontology.yaml
@@ -1,0 +1,101 @@
+- MaaS-Models:
+  - OntologyNode:
+    examples:
+    - Version 2.0 estimates of total number of people per grid square for five timepoints
+      between 2000 and 2020 at five year intervals; national totals have been adjusted
+      to match UN Population Division estimates for each time point.This dataset is
+      a mosaic of all WorldPop country level African datasets resampled to 1km resolution.
+      The continental grouping of countries honours the macro geographical classification
+      developed and maintained by the United Nations Statistics Division. For countries
+      within each continental group which have not been mapped by WorldPop, GPWv4
+      1km population count data was used to complete the mosaic. Full details of WorldPop
+      population mapping methodologies are described at www.worldpop.org.uk/data/methods/
+    name: world_population_africa
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The population model is grounded on a method called Component Analysis (or Component
+      Method) 1, which takes into account Crude Birth Rates (CBR), Crude Death Rates
+      (CDR), and migration rates (inmigration and outmigration). Any of these rates
+      may change in a linear or non-linear fashion.popt = popt-1 + popt-1 * CBRt*(1
+      + birth_rate_fct) - popt-1 * CDRt *(1 + death_rate_fct) + Immigrationt- OutmigrationtIn
+      this equaiton, death/birth_rate fct is applied to the nominal growth rates.
+      It is used for sensitivity studies of changes in the growth rate. For example,
+      if one uses a birth_rate_fct of 0.1 this will boost the nominal growth rates
+      by 10%. These variables are put in place to account for any possible bias in
+      the census data.
+    name: population_model
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - This model uses remote sensing imagery to predict consumption.
+    name: consumption_model
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - NCEP’s Global Ensemble Forecast System (GEFS) is a weather forecast system that
+      provides daily forecasts out to 16 days at 1 X 1 degree resolution at 6-hour
+      intervals. This forecast product can be very useful to early warning famine
+      and hydrological monitoring efforts, so the Climate Hazards Group (CHG) creates
+      forecast precipitation fields at the dekadal (10 day) time scale and makes those
+      available to researchers and decision makers.
+    name: CHIRPS-GEFS
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Currently, the malnutrition model takes the following input variables CHIRPS,
+      Consumer Price Index(CPI), population, cereal production per capita, consumption
+      expenditure,Normalized Difference Vegetation Index (NDVI),and month to predict
+      the malnutrition rates for Global Acute Malnutrition (GAM) and Severe Acute
+      Malnutrition (SAM). According to World Health Organization (WHO) guideline,
+      GAM and SAM are defined as weight-for-height z-score below -2, and weight-for-height
+      z-score below -3, respectively. By this definition, GAM includes all categories
+      of malnutrition.
+    name: malnutrition_model
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The Food Shocks Cascade Model (FSC) is a simple agent-based network model that
+      computes chain-reactions due to negative production anomalies based on dynamic
+      food balance sheets at the country level.
+    name: FSC
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - This model uses remote sensing imagery to predict asset wealth.
+    name: asset_wealth_model
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Climate Hazards Group InfraRed Precipitation with Station data (CHIRPS) is a
+      35+ year quasi-global rainfall data set. Spanning 50°S-50°N (and all longitudes)
+      and ranging from 1981 to near-present, CHIRPS incorporates our in-house climatology,
+      CHPclim, 0.05° resolution satellite imagery, and in-situ station data to create
+      gridded rainfall time series for trend analysis and seasonal drought monitoring.
+    name: CHIRPS
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The Decision Support System for Agrotechnology Transfer (DSSAT) comprises dynamic
+      crop growth simulation model for over 40 crops. The model simulates growth development;
+      and yield as a function of the soil-plant-atmosphere dynamics.
+    name: DSSAT
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - We use LPJmL, a well-established dynamic global vegetation, hydrology and crop-growth
+      model, to simulate wheat, maize and millet yield anomalies for 2018 based on
+      climate, soil conditions and management regimes. Observed weather data are fed
+      into the model until April 30, 2018; afterwards, to simulate the uncertainty
+      of operational forecasts, weather data is sourced from the portion May 01-Dec
+      31 from the previous years (1984-2017). The crop model runs on a global grid
+      with 0.5° size in latitude and longitude.We provide yield anomalies as deviation
+      from the mean of 2013-2017 as simulated by LPJmL. The data is available on a
+      global grid and as nationally aggregated anomalies. Apart from a default simulation,
+      assuming the same management in 2018 as for the previous years, we provide alternative
+      intervention scenarios that assume different irrigation levels, more nitrogen
+      input, or both. In total, there are 3 (crops) * 12 (scenarios) = 36 hypothetical
+      back-casting simulations. Each of these scenarios is calculated for each of
+      the 34 different 2018 climate realizations.
+    name: yield_anomalies_lpjml
+    polarity: 1.0

--- a/metadata/ontologies/MaaS-parameter-ontology.yaml
+++ b/metadata/ontologies/MaaS-parameter-ontology.yaml
@@ -1,0 +1,251 @@
+- MaaS-Parameters:
+  - OntologyNode:
+    examples:
+    - Select the year of the population estimate.
+    model: world_population_africa
+    name: year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Select the country of interest.
+    model: population_model
+    name: country
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Select the year of interest. 2008-2020 is available for South Sudan, and  2000-2020
+      is available for Ethiopia. '
+    model: population_model
+    name: year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - This should be one of ['mm_data','mm_anomaly','none_z-score']. mm_data is the
+      CHIRPS estimates  of precipitation. The mm_anomaly provides the data value minus
+      the mean of the entire time  series up to the previous year. none_z-score provides
+      the Standardized Precipitation Indexes (SPI)  of the estimates.
+    model: CHIRPS-GEFS
+    name: _type
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - A zero padded value for the dekad of the year, 01-36 (a 10 day period).
+    model: CHIRPS-GEFS
+    name: dekad
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The year in YYYY format for the data of interest.
+    model: CHIRPS-GEFS
+    name: year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'The geospatial bounding box of interest. It should represent 4-elements in
+      the WGS84  coordinate system: [xmin, ymin, xmax, ymax]. x is longitude, y is
+      latitude. In other  words, the coordinates of a SW point and a NE point define
+      your region of interest.'
+    model: CHIRPS-GEFS
+    name: bbox
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The rainfall scenario based on historical monthly average of the precipitation
+      values. High value is estimated by 2x mean, and low value is estimated by 0.25x
+      mean.
+    model: malnutrition_model
+    name: rainfall_scenario
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Select the country of interest.
+    model: malnutrition_model
+    name: country
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Select the year of interest. June, 2011 - April, 2019 is available for South
+      Sudan. Jan, 2007 - April 2019 is available for Ethiopia.
+    model: malnutrition_model
+    name: year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Select the month of interest. June, 2011 - April, 2019 is available for South
+      Sudan. Jan, 2007 - April 2019 is available for Ethiopia.
+    model: malnutrition_model
+    name: month
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Select the country for which to induce a food shock (ISO-3 format).
+    model: FSC
+    name: country
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The fraction of reserves that countries can access. Between 0 and 1, where 0
+      indicates that  countries cannot access there reserves and 1 indicates that
+      countries can access the entirety  of their reserves.
+    model: FSC
+    name: fractional_reserve_access
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The percent decrease in crop production due to the shock on the target country
+      (the size  of the shock).
+    model: FSC
+    name: production_decrease
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The year in which to induce the shock in YYYY format.
+    model: FSC
+    name: year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - This should be one of ['mm_data','mm_anomaly','none_z-score']. mm_data is the
+      CHIRPS estimates  of precipitation. The mm_anomaly provides the data value minus
+      the mean of the entire time  series up to the previous year. none_z-score provides
+      the Standardized Precipitation Indexes (SPI)  of the estimates.
+    model: CHIRPS
+    name: _type
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - A zero padded value for the dekad of the year, 01-36 (a 10 day period).
+    model: CHIRPS
+    name: dekad
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The year in YYYY format for the data of interest.
+    model: CHIRPS
+    name: year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'The geospatial bounding box of interest. It should represent 4-elements in
+      the WGS84  coordinate system: [xmin, ymin, xmax, ymax]. x is longitude, y is
+      latitude. In other  words, the coordinates of a SW point and a NE point define
+      your region of interest.'
+    model: CHIRPS
+    name: bbox
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The number of pixel predictions DSSAT will make. Setting samples to 0 returns
+      the  entire geography (all Ethiopia) which is quite large.
+    model: DSSAT
+    name: samples
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'The management practice to model. maize_rf_highN corresponds to a high nitrogen
+      management  practice. maize_irrig corresponds to a high nitrogen, irrigated
+      management practice. maize_rf_0N  corresponds to a subsistence management practice.
+      maize_rf_lowN corresponds to a low nitrogen  managemet practice. If set to combined,
+      all practices are produced. '
+    model: DSSAT
+    name: management_practice
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The year to begin the simulation. The earliest possible year to begin is 1984
+      and the latest is  2019.
+    model: DSSAT
+    name: start_year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The number of years to run the simulation. If start_year + number_years - 1
+      > 2018 then this  will be set such that your simulation runs through 2018.
+    model: DSSAT
+    name: number_years
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - The degree to perturb rainfall from the baseline model. This should be a real
+      number,  which, if 0, would indicate no rainfall in any district. If 1 it would
+      indicate rainfall matching baseline estimates. 1.25 would indicate a 25% increase
+      in rainfall from off the baseline estimate.
+    model: DSSAT
+    name: rainfall
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - This a scalar between 0 and 200 which represents fertilizer in kg/ha. 100 is
+      considered the  baseline amount (per management practice), so anything above
+      100 represents additional  fertilizer usage/availability and anything below
+      100 represents decreased fertilzer (per  management practice).
+    model: DSSAT
+    name: fertilizer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - This is the month and day in "mm-dd" format when planting should begin. This
+      allows the modeler  to simulate various planting seasons (such as Belg and Maher).
+    model: DSSAT
+    name: planting_start
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - This is the month and day in "mm-dd" format when planting should end. This allows
+      the modeler  to simulate various planting seasons (such as Belg and Maher).
+      This must be after the  planting_start parameter.
+    model: DSSAT
+    name: planting_end
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Choose the crop of interest from one of [millet, maize, wheat].
+    model: yield_anomalies_lpjml
+    name: crop
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Choose the irrigation level. It should be one of [LIM, NO, POT]. NO: no irrigation
+      anywhere. Crops are rain-fed only. This can be considered as a "what-if irrigation
+      failed scenario".  LIM: irrigation is applied on crop-specific areas equipped
+      for irrigation. Irrigation water withdrawal is limited to water available in
+      surface water bodies. As a result, it is possible that irrigation demand cannot
+      be fulfilled completely in some grid cells if demand is higher than supply.  POT:
+      uses the same irrigated areas as LIM_IRRIGATION, but allows for withdrawals
+      to exceed water available in surface water bodies. As a result, irrigated crops
+      should not experience water stress.'
+    model: yield_anomalies_lpjml
+    name: irrigation
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Choose the nitrogen level. It should be one of [LIM, LIM_p25, LIM_p50, UNLIM].  LIM:
+      country- and crop-type-specific amounts of N fertilizer to crops. The dataset
+      is from GGCMI (the Global Gridded Crop Model Inter-comparison within AgMIP)
+      and describes fertilizer application levels around the year 2000.  LIM_p25:
+      same as LIM, but with 25% more fertilizer in all cells where N>0. That is, cells
+      without fertilization around 2000 in our data set do also not receive fertilizer
+      in this scenario.  LIM_p50: similar to _p25, but with 50% more N.  UNLIM: extremely
+      high N rates in all cells such that there should be no N limitation of crop
+      growth. There are no negative effects of too much nitrogen on plant growth in
+      our model (but there will be increased leaching and outgassing).'
+    model: yield_anomalies_lpjml
+    name: nitrogen
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Either global (global pixel tif file) or merged (a txt file aggregated to the
+      country level).
+    model: yield_anomalies_lpjml
+    name: area
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Only provide if area=global. Select the statistical aggregation over possible
+      future climate  realizations which can be any of ["mean", "std", "pctl,5", "pctl,95"]
+      for the mean, standard  deviation, 5th percentile or 95th percentile. These
+      four measures reflect the uncertainty of  the climate forecasts starting in
+      May 2018.
+    model: yield_anomalies_lpjml
+    name: statistic
+    polarity: 1.0

--- a/metadata/ontologies/MaaS-variable-ontology.yaml
+++ b/metadata/ontologies/MaaS-variable-ontology.yaml
@@ -1,0 +1,117 @@
+- MaaS-Variables:
+  - OntologyNode:
+    examples:
+    - pixel value corresponds to the population residing there.
+    model: world_population_africa
+    name: population
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - pixel value corresponds to the population residing there.
+    model: population_model
+    name: population
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Measure of how much a person would spend each day (2011 USD per capita per day)
+    model: consumption_model
+    name: consumption per capita per day
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - rainfall in mm per 5km
+    model: CHIRPS-GEFS
+    name: Rainfall
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Rainfall relative to the historic average in mm per 5km
+    model: CHIRPS-GEFS
+    name: Rainfall relative to average
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Standardized Precipitation Index
+    model: CHIRPS-GEFS
+    name: SPI
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - pixel value corresponds to predicted number of malnutrition cases.
+    model: malnutrition_model
+    name: malnutrition
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Change in crop stock reserve levels
+    model: FSC
+    name: dR
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Change in consumption
+    model: FSC
+    name: dC
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Change in production levels
+    model: FSC
+    name: dP
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Measure of household poverty levels based on the assets they own (unitless)
+    model: asset_wealth_model
+    name: poverty level
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - rainfall in mm per 5km
+    model: CHIRPS
+    name: Rainfall
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Rainfall relative to the historic average in mm per 5km
+    model: CHIRPS
+    name: Rainfall relative to average
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Standardized Precipitation Index
+    model: CHIRPS
+    name: SPI
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvested weight at harvest (kg/ha)
+    model: DSSAT
+    name: HWAH
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Amount of area harvested under all management practices for this point (ha)
+    model: DSSAT
+    name: HARVEST_AREA
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Yield for the given point/management practice (kg)
+    model: DSSAT
+    name: Yield
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Indicates the type of management practice for the given yield/point combination.  1
+      corresponds to high nitrogen, 2 to irrigated high nitrogen, 3 to  subsistence,
+      and 4 to low nitrogen.
+    model: DSSAT
+    name: management_practice
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Percent increase or decrease in yield from baseline
+    model: yield_anomalies_lpjml
+    name: yield level
+    polarity: 1.0


### PR DESCRIPTION
Adds in a script called `Metadata-to-Ontologies.py` in the `metadata` directory. When invoked, this script generates an ontology for each of `models`, `variables`, and `parameters` in the expected UAZ format.