### PR TITLE
/model_outputs endpoint

### DIFF
--- a/REST-Server/openapi_server/controllers/concepts_controller.py
+++ b/REST-Server/openapi_server/controllers/concepts_controller.py
@@ -15,15 +15,15 @@ r = redis.Redis(host=config['REDIS']['HOST'],
                 port=config['REDIS']['PORT'],
                 db=config['REDIS']['DB'])
 
-def concept_mapping_post(concept, concept_type=None):  # noqa: E501
+def concept_mapping_get(concept=None, concept_type=None):  # noqa: E501
     """Obtain an array of models related to a concept.
 
-    Submit a concept name and optional type and receive an array of model related to that concept.        # noqa: E501
+    Submit a concept name and optional type and receive an array of concepts related to that concept.        # noqa: E501
 
     :param concept: A concept name
     :type concept: str
-    :param type: The type of object to return
-    :type type: str
+    :param concept_type: The type of concept objects to return
+    :type concept_type: str
 
     :rtype: List[Concept]
     """

--- a/REST-Server/openapi_server/controllers/exploration_controller.py
+++ b/REST-Server/openapi_server/controllers/exploration_controller.py
@@ -104,65 +104,18 @@ def model_info_model_name_get(ModelName):  # noqa: E501
     return util.format_model(m)
 
 
-def model_io_post():  # noqa: E501
-    """Obtain information on a given model&#39;s inputs or outputs.
+def model_outputs_model_name_get(ModelName):  # noqa: E501
+    """Obtain information on a given model&#39;s outputs.
 
-    Submit a model name and receive information about the input or output files required by this model. # noqa: E501
-    Note that this includes all inputs and all outputs for a given model, irrespective of the 
-    configuration. In the future this could be subset to just a specific configuration.
+    Submit a model name and receive information about the output variables produced by this model. # noqa: E501
 
-    :param io_request: The name of a model and an IO type.
-    :type io_request: dict | bytes
+    :param model_name: The name of a model.
+    :type model_name: str
 
-    :rtype: List[IOFile]
+    :rtype: List[Variable]
     """
-    if connexion.request.is_json:
-        io_request = IORequest.from_dict(connexion.request.get_json())  # noqa: E501
-        name_ = io_request.name
-        type_ = io_request.iotype
-
-        try:
-            # get model configuration ids
-            api_instance = mint_client.ModelApi(mint_client.ApiClient(configuration))
-            model = api_instance.get_model(name_, username=username)
-            versions = [v['id'] for v in model.has_software_version]
-            
-
-            # for each model version, obtain configuration ids
-            configuration_ids = []
-            api_instance = mint_client.ModelversionApi(mint_client.ApiClient(configuration))
-            for v in versions:
-                version = api_instance.get_model_version(v, username=username)
-                c_ids = [c.id for c in version.has_configuration]
-                configuration_ids.extend(c_ids)
-
-            # get IO
-            api_instance = mint_client.ModelconfigurationApi(mint_client.ApiClient(configuration))
-
-            inputs_outputs = []
-            if type_ == 'input':
-                for config_id in configuration_ids:
-                    response = requests.get(f"https://api.models.mint.isi.edu/v0.0.2/modelconfiguration/{config_id}/inputs?username=modelservice")
-                    api_response = response.json()
-
-                    for io in api_response:
-                        io_ = util._parse_io(io, url, request_headers)
-                        if io_:
-                            inputs_outputs.append(io_)
-
-            elif type_ == 'output':
-                outputs = []
-                for config_id in configuration_ids:
-                    response = requests.get(f"https://api.models.mint.isi.edu/v0.0.2/modelconfiguration/{config_id}/outputs?username=modelservice")
-                    api_response = response.json()
-                    for io in api_response:
-                        io_ = util._parse_io(io, url, request_headers)
-                        if io_:
-                            inputs_outputs.append(io_)
-            return inputs_outputs
-
-        except ApiException as e:
-            return "Exception when calling MINT API: %s\n" % e
+    m = json.loads(r.get(f'{ModelName}-meta').decode('utf-8'))
+    return util.format_outputs(m)
 
 
 def model_parameters_model_name_get(ModelName):  # noqa: E501

--- a/REST-Server/openapi_server/models/variable.py
+++ b/REST-Server/openapi_server/models/variable.py
@@ -15,15 +15,13 @@ class Variable(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, name=None, standard_names=None, standard_name_ontology=None, units=None, metadata=None):  # noqa: E501
+    def __init__(self, name=None, description=None, units=None, metadata=None):  # noqa: E501
         """Variable - a model defined in OpenAPI
 
         :param name: The name of this Variable.  # noqa: E501
         :type name: str
-        :param standard_names: The standard_names of this Variable.  # noqa: E501
-        :type standard_names: List[StandardName]
-        :param standard_name_ontology: The standard_name_ontology of this Variable.  # noqa: E501
-        :type standard_name_ontology: str
+        :param description: The description of this Variable.  # noqa: E501
+        :type description: str
         :param units: The units of this Variable.  # noqa: E501
         :type units: str
         :param metadata: The metadata of this Variable.  # noqa: E501
@@ -31,23 +29,20 @@ class Variable(Model):
         """
         self.openapi_types = {
             'name': str,
-            'standard_names': List[StandardName],
-            'standard_name_ontology': str,
+            'description': str,
             'units': str,
             'metadata': object
         }
 
         self.attribute_map = {
             'name': 'name',
-            'standard_names': 'standard_names',
-            'standard_name_ontology': 'standard_name_ontology',
+            'description': 'description',
             'units': 'units',
             'metadata': 'metadata'
         }
 
         self._name = name
-        self._standard_names = standard_names
-        self._standard_name_ontology = standard_name_ontology
+        self._description = description
         self._units = units
         self._metadata = metadata
 
@@ -86,48 +81,27 @@ class Variable(Model):
         self._name = name
 
     @property
-    def standard_names(self):
-        """Gets the standard_names of this Variable.
+    def description(self):
+        """Gets the description of this Variable.
 
 
-        :return: The standard_names of this Variable.
-        :rtype: List[StandardName]
-        """
-        return self._standard_names
-
-    @standard_names.setter
-    def standard_names(self, standard_names):
-        """Sets the standard_names of this Variable.
-
-
-        :param standard_names: The standard_names of this Variable.
-        :type standard_names: List[StandardName]
-        """
-        if standard_names is None:
-            raise ValueError("Invalid value for `standard_names`, must not be `None`")  # noqa: E501
-
-        self._standard_names = standard_names
-
-    @property
-    def standard_name_ontology(self):
-        """Gets the standard_name_ontology of this Variable.
-
-
-        :return: The standard_name_ontology of this Variable.
+        :return: The description of this Variable.
         :rtype: str
         """
-        return self._standard_name_ontology
+        return self._description
 
-    @standard_name_ontology.setter
-    def standard_name_ontology(self, standard_name_ontology):
-        """Sets the standard_name_ontology of this Variable.
+    @description.setter
+    def description(self, description):
+        """Sets the description of this Variable.
 
 
-        :param standard_name_ontology: The standard_name_ontology of this Variable.
-        :type standard_name_ontology: str
+        :param description: The description of this Variable.
+        :type description: str
         """
+        if description is None:
+            raise ValueError("Invalid value for `description`, must not be `None`")  # noqa: E501
 
-        self._standard_name_ontology = standard_name_ontology
+        self._description = description
 
     @property
     def units(self):

--- a/REST-Server/openapi_server/openapi/openapi.yaml
+++ b/REST-Server/openapi_server/openapi/openapi.yaml
@@ -48,25 +48,29 @@ paths:
       tags:
       - exploration
       x-openapi-router-controller: openapi_server.controllers.exploration_controller
-  /model_io:
-    post:
-      description: Submit a model name and receive information about the input or output files required by this model.
-      operationId: model_io_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/IORequest'
-        description: The name of a model and an IO type.
+  /model_outputs/{ModelName}:
+    get:
+      description: Submit a model name and receive information about the output variables produced by this model.
+      operationId: model_outputs_model_name_get
+      parameters:
+      - description: The name of a model.
+        explode: false
+        in: path
+        name: ModelName
         required: true
+        schema:
+          $ref: '#/components/schemas/ModelName'
+        style: simple
       responses:
         200:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ModelIO'
+                items:
+                  $ref: '#/components/schemas/Variable'
+                type: array
           description: SUCCESS
-      summary: Obtain information on a given model's inputs or outputs.
+      summary: Obtain information on a given model's outputs.
       tags:
       - exploration
       x-openapi-router-controller: openapi_server.controllers.exploration_controller
@@ -172,8 +176,8 @@ paths:
   /concept_mapping:
     get:
       description: "Submit a concept name and optional type and receive an array of\
-        \ model related to that concept.      \n"
-      operationId: concept_mapping_post
+        \ concepts related to that concept.      \n"
+      operationId: concept_mapping_get
       parameters:
       - description: A concept name
         explode: true
@@ -183,7 +187,7 @@ paths:
         schema:
           $ref: '#/components/schemas/ConceptName'
         style: form
-      - description: The type of object to return
+      - description: The type of concept objects to return
         explode: true
         in: query
         name: concept_type
@@ -365,10 +369,6 @@ components:
       type: string
     StandardName:
       description: A standard name representation
-      example:
-        standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-        standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-        standard_variable_name: year
       properties:
         standard_variable_id:
           description: The MINT UUID associated with the standard name
@@ -446,79 +446,6 @@ components:
         $ref: '#/components/schemas/Model'
       type: array
       uniqueItems: true
-    ModelIO:
-      description: Array of input or output files for the given model.
-      items:
-        $ref: '#/components/schemas/IOFile'
-      type: array
-    IOFile:
-      description: An object that defines a single input or output file for a model
-      example:
-        filetype: WTH
-        variables:
-        - metadata: '{}'
-          standard_names:
-          - standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-            standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-            standard_variable_name: year
-          - standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-            standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-            standard_variable_name: year
-          name: name
-          standard_name_ontology: standard_name_ontology
-          units: units
-        - metadata: '{}'
-          standard_names:
-          - standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-            standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-            standard_variable_name: year
-          - standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-            standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-            standard_variable_name: year
-          name: name
-          standard_name_ontology: standard_name_ontology
-          units: units
-        name: NASA-POWER Weather Data
-        description: Weather data from the NASA-POWER database. This database provides historical global weather data, including a minimum dataset of DSSAT, on 1-degree grids in ICASA Standards format.
-      properties:
-        name:
-          description: The name of a given input or output file. This should be general and should not reference a specific file.
-          example: NASA-POWER Weather Data
-          type: string
-        description:
-          description: Description of the file.
-          example: Weather data from the NASA-POWER database. This database provides historical global weather data, including a minimum dataset of DSSAT, on 1-degree grids in ICASA Standards format.
-          type: string
-        filetype:
-          description: The file type (extension) for this file
-          example: WTH
-          type: string
-        variables:
-          description: An array of variables associated with a given input or output file
-          items:
-            $ref: '#/components/schemas/Variable'
-          type: array
-      required:
-      - description
-      - filetype
-      - name
-      type: object
-    IORequest:
-      description: A request object indicating whether the response should return either input or output files and for which model
-      example:
-        name: FSC
-        iotype: input
-      properties:
-        name:
-          description: A model's name
-          example: FSC
-          type: string
-        iotype:
-          enum:
-          - input
-          - output
-          type: string
-      type: object
     ModelConfig:
       description: A model configuration file (JSON).
       example:
@@ -539,32 +466,21 @@ components:
       description: A variable used in a model input or output file.
       example:
         metadata: '{}'
-        standard_names:
-        - standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-          standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-          standard_variable_name: year
-        - standard_variable_uri: http://www.geoscienceontology.org/svo/svl/property#year
-          standard_variable_id: df1daca4-d727-5dc8-bfa4-fb20c717a32b
-          standard_variable_name: year
         name: name
-        standard_name_ontology: standard_name_ontology
+        description: description
         units: units
       properties:
         name:
           type: string
-        standard_names:
-          items:
-            $ref: '#/components/schemas/StandardName'
-          type: array
-        standard_name_ontology:
+        description:
           type: string
         units:
           type: string
         metadata:
           type: object
       required:
+      - description
       - name
-      - standard_names
       type: object
     Parameter:
       description: A user configurable model parameter

--- a/REST-Server/openapi_server/test/test_exploration_controller.py
+++ b/REST-Server/openapi_server/test/test_exploration_controller.py
@@ -6,12 +6,11 @@ from flask import json
 from six import BytesIO
 
 from openapi_server.models.error import Error  # noqa: E501
-from openapi_server.models.io_file import IOFile  # noqa: E501
-from openapi_server.models.io_request import IORequest  # noqa: E501
 from openapi_server.models.model import Model  # noqa: E501
 from openapi_server.models.model_config import ModelConfig  # noqa: E501
 from openapi_server.models.parameter import Parameter  # noqa: E501
 from openapi_server.models.unknownbasetype import UNKNOWN_BASE_TYPE  # noqa: E501
+from openapi_server.models.variable import Variable  # noqa: E501
 from openapi_server.test import BaseTestCase
 
 
@@ -51,17 +50,14 @@ class TestExplorationController(BaseTestCase):
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 
-    def test_model_io_post(self):
-        """Test case for model_io_post
+    def test_model_outputs_model_name_get(self):
+        """Test case for model_outputs_model_name_get
 
-        Obtain information on a given model's inputs or outputs.
+        Obtain information on a given model's outputs.
         """
-        io_request = IORequest()
         response = self.client.open(
-            '/model_io',
-            method='POST',
-            data=json.dumps(io_request),
-            content_type='application/json')
+            '/model_outputs/{ModelName}'.format(model_name='model_name_example'),
+            method='GET')
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 

--- a/REST-Server/openapi_server/util.py
+++ b/REST-Server/openapi_server/util.py
@@ -585,6 +585,22 @@ def format_parameters(m):
         out_p.append(o_p)
     return out_p
 
+def format_outputs(m):
+    """
+    Takes in  a model metadata JSON from Redis and formats the outputs for the MaaS API.
+    """
+    outputs = m.get('outputs',[])
+    out_o = []
+    for o in outputs:
+        o_ = {'name': o['name'],
+              'description': o['description'].replace('\n','')}
+        if 'units' in o:
+            o_['units'] = o.get('units','')
+        if 'metadata' in o:
+            o_['metadata'] = o.get('units','')            
+        out_o.append(o_)
+    return out_o
+
 def format_config(m):
     """
     Takes in  a model metadata JSON from Redis and formats the config the MaaS API.

--- a/metadata/models/CHIRPS-GEFS-model-metadata.yaml
+++ b/metadata/models/CHIRPS-GEFS-model-metadata.yaml
@@ -28,6 +28,7 @@ concepts:
 outputs:
 - name: Rainfall
   description: rainfall in mm per 5km
+  units: mm per 5km
   concepts:
   - wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall: 0.6317845
   - wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall: 0.6317845
@@ -41,6 +42,7 @@ outputs:
   - wm/concept/causal_factor/environmental/meteorologic/climate: 0.42092496
 - name: Rainfall relative to average
   description: Rainfall relative to the historic average in mm per 5km
+  units: mm per 5km
   concepts:
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.5872121
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.5872121
@@ -53,7 +55,8 @@ outputs:
   - wm/concept/causal_factor/condition/trend: 0.51264393
   - wm/concept/causal_factor/condition/trend: 0.51264393
 - name: SPI
-  description: Standardized Precipitation Index
+  description: Standardized Precipitation Index reflects the number of standard deviations by which the observed anomaly deviates from the long-term mean
+  units: unitless index
   concepts:
   - wm/concept/causal_factor/social_and_political/government/census: 0.29142399999999996
   - wm/concept/causal_factor/social_and_political/government/census: 0.29142399999999996

--- a/metadata/models/CHIRPS-model-metadata.yaml
+++ b/metadata/models/CHIRPS-model-metadata.yaml
@@ -26,6 +26,7 @@ concepts:
 outputs:
 - name: Rainfall
   description: rainfall in mm per 5km
+  units: mm per 5km  
   concepts:
   - wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall: 0.6317845
   - wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall: 0.6317845
@@ -39,6 +40,7 @@ outputs:
   - wm/concept/causal_factor/environmental/meteorologic/climate: 0.42092496
 - name: Rainfall relative to average
   description: Rainfall relative to the historic average in mm per 5km
+  units: mm per 5km
   concepts:
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.5872121
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.5872121
@@ -51,7 +53,8 @@ outputs:
   - wm/concept/causal_factor/condition/trend: 0.51264393
   - wm/concept/causal_factor/condition/trend: 0.51264393
 - name: SPI
-  description: Standardized Precipitation Index
+  description: Standardized Precipitation Index reflects the number of standard deviations by which the observed anomaly deviates from the long-term mean
+  units: unitless index
   concepts:
   - wm/concept/causal_factor/social_and_political/government/census: 0.29142399999999996
   - wm/concept/causal_factor/social_and_political/government/census: 0.29142399999999996

--- a/metadata/models/DSSAT-model-metadata.yaml
+++ b/metadata/models/DSSAT-model-metadata.yaml
@@ -24,6 +24,7 @@ concepts:
 outputs:
 - name: HWAH
   description: Harvested weight at harvest (kg/ha)
+  units: kg/ha
   concepts:
   - wm/concept/causal_factor/agriculture/crop_production: 0.58487195
   - wm/concept/time/temporal/crop_season: 0.5828258000000001
@@ -38,6 +39,7 @@ outputs:
 - name: HARVEST_AREA
   description: Amount of area harvested under all management practices for this point
     (ha)
+  units: ha    
   concepts:
   - wm/concept/causal_factor/environmental/resource_management: 0.5725762
   - wm/concept/time/temporal/crop_season: 0.5657956000000001
@@ -51,6 +53,7 @@ outputs:
   - wm/concept/causal_factor/social_and_political/educational/educational_materials: 0.5230878999999999
 - name: Yield
   description: Yield for the given point/management practice (kg)
+  units: kg
   concepts:
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/labor_market: 0.5927398
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/demand/food_demand: 0.5618763000000001

--- a/metadata/models/asset-wealth-model-metadata.yaml
+++ b/metadata/models/asset-wealth-model-metadata.yaml
@@ -24,6 +24,7 @@ concepts:
 outputs:
 - name: poverty level
   description: Measure of household poverty levels based on the assets they own (unitless)
+  units: unitless index
   concepts:
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/assets: 0.6052661
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/livelihood: 0.5776428000000001

--- a/metadata/models/consumption-model-metadata.yaml
+++ b/metadata/models/consumption-model-metadata.yaml
@@ -25,6 +25,7 @@ outputs:
 - name: consumption per capita per day
   description: Measure of how much a person would spend each day (2011 USD per capita
     per day)
+  units: 2011 USD
   concepts:
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/revenue: 0.59317344
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/price_or_cost/cost_of_living: 0.5575675

--- a/metadata/models/flood-index-model-metadata.yaml
+++ b/metadata/models/flood-index-model-metadata.yaml
@@ -18,14 +18,17 @@ outputs:
 - name: days_medium
   description: The number of days for the given month where the flood severity index
     was medium (2-year flood)
+  units: days
   concepts: []
 - name: days_high
   description: The number of days for the given month where the flood severity index
     was high (5-year flood)
+  units: days    
   concepts: []
 - name: days_severe
   description: The number of days for the given month where the flood severity index
     was severe (20-year flood)
+  units: days    
   concepts: []
 parameters:
 - name: year

--- a/metadata/models/malnutrition-model-metadata.yaml
+++ b/metadata/models/malnutrition-model-metadata.yaml
@@ -33,6 +33,7 @@ concepts:
 outputs:
 - name: malnutrition
   description: pixel value corresponds to predicted number of malnutrition cases.
+  units: malnutrition cases
   concepts:
   - wm/concept/causal_factor/condition/trend: 0.5463087
   - wm/concept/causal_factor/crisis_and_disaster/environmental_disasters/crop_failure: 0.5214581

--- a/metadata/models/world-population-africa-model-metadata.yaml
+++ b/metadata/models/world-population-africa-model-metadata.yaml
@@ -33,6 +33,7 @@ concepts:
 outputs:
 - name: population
   description: pixel value corresponds to the population residing there.
+  units: people
   concepts:
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.6582799
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.6582799

--- a/metadata/models/yield-anomalies-model-metadata.yaml
+++ b/metadata/models/yield-anomalies-model-metadata.yaml
@@ -36,6 +36,7 @@ concepts:
 outputs:
 - name: yield level
   description: Percent increase or decrease in yield from baseline
+  units: percent  
   concepts:
   - wm/concept/causal_factor/condition/trend: 0.74224097
   - wm/concept/causal_factor/crisis_and_disaster/environmental_disasters/crop_failure: 0.6003543

--- a/model_service_api.yaml
+++ b/model_service_api.yaml
@@ -44,26 +44,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Model'
-  /model_io:
-    post:
+  /model_outputs/{ModelName}:
+    get:
       tags:
       - "exploration"
-      summary: "Obtain information on a given model's inputs or outputs."
-      description: "Submit a model name and receive information about the input or output files required by this model."
-      requestBody:
-        description: "The name of a model and an IO type."
+      summary: "Obtain information on a given model's outputs."
+      description: "Submit a model name and receive information about the output variables produced by this model."
+      parameters:
+      - in: path
+        name: ModelName
+        description: "The name of a model."
         required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/IORequest"
+        schema:
+          $ref: "#/components/schemas/ModelName"
       responses:
         200:
           description: "SUCCESS"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ModelIO'
+                type: "array"
+                items:
+                  $ref: '#/components/schemas/Variable'
   /model_parameters/{ModelName}:
     get:
       tags:
@@ -381,47 +383,6 @@ components:
         $ref: '#/components/schemas/Model'
       uniqueItems: true
       description: "An array of available models"
-    ModelIO:
-      type: "array"
-      description: "Array of input or output files for the given model."
-      items:
-        $ref: '#/components/schemas/IOFile'
-    IOFile:
-      # Note that this explicitly does not require low-level definitions
-      # of a file schema, nor does it require variable definitions
-      type: "object"
-      description: "An object that defines a single input or output file for a model"
-      required:
-        - "name"
-        - "description"
-        - "filetype"
-      properties:
-        name:
-          type: "string"
-          description: "The name of a given input or output file. This should be general and should not reference a specific file."
-          example: "NASA-POWER Weather Data"
-        description:
-          type: "string"
-          description: "Description of the file."
-          example: "Weather data from the NASA-POWER database. This database provides historical global weather data, including a minimum dataset of DSSAT, on 1-degree grids in ICASA Standards format."
-        filetype: 
-          type: "string"
-          description: "The file type (extension) for this file"
-          example: "WTH"
-        variables:
-          type: "array"
-          description: "An array of variables associated with a given input or output file"
-          items:
-            $ref: '#/components/schemas/Variable'
-    IORequest:
-      type: "object"
-      description: "A request object indicating whether the response should return either input or output files and for which model"
-      properties:
-        name:
-          $ref: '#/components/schemas/ModelName'
-        iotype:
-          type: "string"
-          enum: ["input", "output"]
     ModelConfig:
       # this can be an example config, or a config submitted to execute
       # a job. This is loosely defined for the time being.
@@ -443,15 +404,11 @@ components:
       description: "A variable used in a model input or output file."
       required:
         - "name"
-        - "standard_names"
+        - "description"
       properties:
         name: 
           type: "string"
-        standard_names:
-          type: "array"
-          items:
-            $ref: '#/components/schemas/StandardName'
-        standard_name_ontology:
+        description:
           type: "string"
         units:
           type: "string"


### PR DESCRIPTION
## What's New

This PR removes the deprecated `/model_io` endpoint and adds the `/model_outputs` endpoint. This is a nearly direct pass through to the model metadata stored in Redis (from the `*-model-metadata.yaml` files). 

A client can make a `GET` request and provide a model name to the endpoint. The response will be an array of the output variables:

```
 [
   {
    "description": "variable description",
    "name": "variable name",
    "units": "variable units",
   "metadata": {}
  }
]
```

Note that the `metadata` and `units` keys are optional and may not appear for all variables. `metadata` can be an arbitrary dictionary.