### PR TITLE
Added aggregation types (geo/temporal) for each model output

### DIFF
--- a/REST-Server/openapi_server/util.py
+++ b/REST-Server/openapi_server/util.py
@@ -222,12 +222,13 @@ def format_outputs(m):
     outputs = m.get('outputs',[])
     out_o = []
     for o in outputs:
+        o_ = OrderedDict()
         o_ = {'name': o['name'],
               'description': o['description'].replace('\n','')}
         if 'units' in o:
             o_['units'] = o.get('units','')
         if 'metadata' in o:
-            o_['metadata'] = o.get('units','')            
+            o_['metadata'] = o.get('metadata','')            
         out_o.append(o_)
     return out_o
 

--- a/metadata/models/CHIRPS-GEFS-model-metadata.yaml
+++ b/metadata/models/CHIRPS-GEFS-model-metadata.yaml
@@ -29,6 +29,14 @@ outputs:
 - name: Rainfall
   description: rainfall in mm per 5km
   units: mm per 5km
+  metadata:
+    aggregation:
+      geospatial: 
+        default: sum
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std] 
   concepts:
   - wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall: 0.6317845
   - wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall: 0.6317845
@@ -43,6 +51,14 @@ outputs:
 - name: Rainfall relative to average
   description: Rainfall relative to the historic average in mm per 5km
   units: mm per 5km
+  metadata:
+    aggregation:
+      geospatial: 
+        default: sum
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.5872121
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.5872121
@@ -57,6 +73,14 @@ outputs:
 - name: SPI
   description: Standardized Precipitation Index reflects the number of standard deviations by which the observed anomaly deviates from the long-term mean
   units: unitless index
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/social_and_political/government/census: 0.29142399999999996
   - wm/concept/causal_factor/social_and_political/government/census: 0.29142399999999996

--- a/metadata/models/CHIRPS-model-metadata.yaml
+++ b/metadata/models/CHIRPS-model-metadata.yaml
@@ -27,6 +27,14 @@ outputs:
 - name: Rainfall
   description: rainfall in mm per 5km
   units: mm per 5km  
+  metadata:
+    aggregation:
+      geospatial: 
+        default: sum
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall: 0.6317845
   - wm/concept/causal_factor/environmental/meteorologic/precipitation/rainfall: 0.6317845
@@ -41,6 +49,14 @@ outputs:
 - name: Rainfall relative to average
   description: Rainfall relative to the historic average in mm per 5km
   units: mm per 5km
+  metadata:
+    aggregation:
+      geospatial: 
+        default: sum
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.5872121
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.5872121
@@ -55,6 +71,14 @@ outputs:
 - name: SPI
   description: Standardized Precipitation Index reflects the number of standard deviations by which the observed anomaly deviates from the long-term mean
   units: unitless index
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/social_and_political/government/census: 0.29142399999999996
   - wm/concept/causal_factor/social_and_political/government/census: 0.29142399999999996

--- a/metadata/models/DSSAT-model-metadata.yaml
+++ b/metadata/models/DSSAT-model-metadata.yaml
@@ -25,6 +25,14 @@ outputs:
 - name: HWAH
   description: Harvested weight at harvest (kg/ha)
   units: kg/ha
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/agriculture/crop_production: 0.58487195
   - wm/concept/time/temporal/crop_season: 0.5828258000000001
@@ -40,6 +48,14 @@ outputs:
   description: Amount of area harvested under all management practices for this point
     (ha)
   units: ha    
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/environmental/resource_management: 0.5725762
   - wm/concept/time/temporal/crop_season: 0.5657956000000001
@@ -54,6 +70,14 @@ outputs:
 - name: Yield
   description: Yield for the given point/management practice (kg)
   units: kg
+  metadata:
+    aggregation:
+      geospatial: 
+        default: sum
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/labor_market: 0.5927398
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/demand/food_demand: 0.5618763000000001

--- a/metadata/models/asset-wealth-model-metadata.yaml
+++ b/metadata/models/asset-wealth-model-metadata.yaml
@@ -25,6 +25,14 @@ outputs:
 - name: poverty level
   description: Measure of household poverty levels based on the assets they own (unitless)
   units: unitless index
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]
   concepts:
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/assets: 0.6052661
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/livelihood: 0.5776428000000001

--- a/metadata/models/consumption-model-metadata.yaml
+++ b/metadata/models/consumption-model-metadata.yaml
@@ -26,6 +26,14 @@ outputs:
   description: Measure of how much a person would spend each day (2011 USD per capita
     per day)
   units: 2011 USD
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/revenue: 0.59317344
   - wm/concept/causal_factor/economic_and_commerce/economic_activity/market/price_or_cost/cost_of_living: 0.5575675

--- a/metadata/models/flood-index-model-metadata.yaml
+++ b/metadata/models/flood-index-model-metadata.yaml
@@ -19,16 +19,40 @@ outputs:
   description: The number of days for the given month where the flood severity index
     was medium (2-year flood)
   units: days
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts: []
 - name: days_high
   description: The number of days for the given month where the flood severity index
     was high (5-year flood)
-  units: days    
+  units: days   
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]   
   concepts: []
 - name: days_severe
   description: The number of days for the given month where the flood severity index
     was severe (20-year flood)
   units: days    
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts: []
 parameters:
 - name: year

--- a/metadata/models/malnutrition-model-metadata.yaml
+++ b/metadata/models/malnutrition-model-metadata.yaml
@@ -34,6 +34,14 @@ outputs:
 - name: malnutrition
   description: pixel value corresponds to predicted number of malnutrition cases.
   units: malnutrition cases
+  metadata:
+    aggregation:
+      geospatial: 
+        default: sum
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/condition/trend: 0.5463087
   - wm/concept/causal_factor/crisis_and_disaster/environmental_disasters/crop_failure: 0.5214581

--- a/metadata/models/population-model-metadata.yaml
+++ b/metadata/models/population-model-metadata.yaml
@@ -38,6 +38,15 @@ concepts:
 outputs:
 - name: population
   description: pixel value corresponds to the population residing there.
+  units: number of people
+  metadata:
+    aggregation:
+      geospatial: 
+        default: sum
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.6582799
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.6582799

--- a/metadata/models/world-population-africa-model-metadata.yaml
+++ b/metadata/models/world-population-africa-model-metadata.yaml
@@ -33,7 +33,15 @@ concepts:
 outputs:
 - name: population
   description: pixel value corresponds to the population residing there.
-  units: people
+  units: number of people
+  metadata:
+    aggregation:
+      geospatial: 
+        default: sum
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.6582799
   - wm/concept/causal_factor/social_and_political/population_group/population_density: 0.6582799

--- a/metadata/models/yield-anomalies-model-metadata.yaml
+++ b/metadata/models/yield-anomalies-model-metadata.yaml
@@ -37,6 +37,14 @@ outputs:
 - name: yield level
   description: Percent increase or decrease in yield from baseline
   units: percent  
+  metadata:
+    aggregation:
+      geospatial: 
+        default: average
+        allowed: [average, sum, min, max, std]
+      temporal: 
+        default: average
+        allowed: [average, sum, min, max, std]  
   concepts:
   - wm/concept/causal_factor/condition/trend: 0.74224097
   - wm/concept/causal_factor/crisis_and_disaster/environmental_disasters/crop_failure: 0.6003543


### PR DESCRIPTION
## What's New

This PR adds `metadata` for each model around the aggregation types that should be `default` or are `allowed`. 

> **WARNING that these are notional and should be validated with modeling teams.**

A response from the `/model_outputs` endpoint will not look like:

```
[
  {
    "description": "Harvested weight at harvest (kg/ha)",
    "metadata": {
      "aggregation": {
        "geospatial": {
          "allowed": [
            "average",
            "sum",
            "min",
            "max",
            "std"
          ],
          "default": "average"
        },
        "temporal": {
          "allowed": [
            "average",
            "sum",
            "min",
            "max",
            "std"
          ],
          "default": "average"
        }
      }
    },
    "name": "HWAH",
    "units": "kg/ha"
  }
... etc ...etc ...
]
```